### PR TITLE
[codex] Refactor tests with shared fixtures

### DIFF
--- a/src/test/java/name/krot/smartlinks/command/FirstMatchingRedirectCommandChainTest.java
+++ b/src/test/java/name/krot/smartlinks/command/FirstMatchingRedirectCommandChainTest.java
@@ -4,10 +4,10 @@ import name.krot.smartlinks.predicate.RequestContext;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,7 +17,7 @@ class FirstMatchingRedirectCommandChainTest {
 
     @Test
     void returnsFirstCommandResult() {
-        RequestContext context = new RequestContext(LocalDateTime.now(), "ru-RU", null);
+        RequestContext context = requestContext("ru-RU");
         URI redirectUri = URI.create("https://otus.ru/ru");
 
         Optional<URI> result = chain.execute(List.of(
@@ -32,7 +32,7 @@ class FirstMatchingRedirectCommandChainTest {
 
     @Test
     void returnsEmptyWhenNoCommandMatches() {
-        RequestContext context = new RequestContext(LocalDateTime.now(), "en-US", null);
+        RequestContext context = requestContext("en-US");
 
         assertTrue(chain.execute(List.of(ignored -> Optional.empty()), context).isEmpty());
     }

--- a/src/test/java/name/krot/smartlinks/command/RuleRedirectCommandFactoryTest.java
+++ b/src/test/java/name/krot/smartlinks/command/RuleRedirectCommandFactoryTest.java
@@ -8,6 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.DEFAULT_REDIRECT_URL;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.RU_REDIRECT_URL;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.fallbackRule;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -20,19 +24,10 @@ class RuleRedirectCommandFactoryTest {
 
     @Test
     void createsOneCommandPerRule() {
-        SmartLink smartLink = new SmartLink();
-        smartLink.setId("smartlink123");
-        smartLink.setRules(List.of(rule("https://otus.ru/ru"), rule("https://otus.ru/default")));
+        SmartLink smartLink = smartLink(fallbackRule(RU_REDIRECT_URL), fallbackRule(DEFAULT_REDIRECT_URL));
 
         List<RedirectCommand> commands = factory.createCommands(smartLink);
 
         assertEquals(2, commands.size());
-    }
-
-    private static Rule rule(String redirectTo) {
-        Rule rule = new Rule();
-        rule.setPredicates(List.of());
-        rule.setRedirectTo(redirectTo);
-        return rule;
     }
 }

--- a/src/test/java/name/krot/smartlinks/command/RuleRedirectCommandTest.java
+++ b/src/test/java/name/krot/smartlinks/command/RuleRedirectCommandTest.java
@@ -7,10 +7,12 @@ import name.krot.smartlinks.service.RedirectUriResolver;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.RU_REDIRECT_URL;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.rule;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -23,9 +25,9 @@ class RuleRedirectCommandTest {
 
     @Test
     void returnsRedirectWhenRuleMatches() {
-        Rule rule = rule();
-        RequestContext context = new RequestContext(LocalDateTime.now(), "ru-RU", null);
-        URI redirectUri = URI.create("https://otus.ru/ru");
+        Rule rule = languageRule();
+        RequestContext context = requestContext("ru-RU");
+        URI redirectUri = URI.create(RU_REDIRECT_URL);
         RuleRedirectCommand command = new RuleRedirectCommand(rule, predicateRuleEvaluator, redirectUriResolver);
 
         when(predicateRuleEvaluator.matches(rule, context)).thenReturn(true);
@@ -39,8 +41,8 @@ class RuleRedirectCommandTest {
 
     @Test
     void returnsEmptyWhenRuleDoesNotMatch() {
-        Rule rule = rule();
-        RequestContext context = new RequestContext(LocalDateTime.now(), "en-US", null);
+        Rule rule = languageRule();
+        RequestContext context = requestContext("en-US");
         RuleRedirectCommand command = new RuleRedirectCommand(rule, predicateRuleEvaluator, redirectUriResolver);
 
         when(predicateRuleEvaluator.matches(rule, context)).thenReturn(false);
@@ -48,10 +50,7 @@ class RuleRedirectCommandTest {
         assertTrue(command.execute(context).isEmpty());
     }
 
-    private static Rule rule() {
-        Rule rule = new Rule();
-        rule.setPredicates(List.of("Language"));
-        rule.setRedirectTo("https://otus.ru/ru");
-        return rule;
+    private static Rule languageRule() {
+        return rule(List.of("Language"), RU_REDIRECT_URL);
     }
 }

--- a/src/test/java/name/krot/smartlinks/controller/RedirectControllerTest.java
+++ b/src/test/java/name/krot/smartlinks/controller/RedirectControllerTest.java
@@ -15,9 +15,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.net.URI;
-import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static name.krot.smartlinks.support.SmartLinkJsonFixtures.fallbackSmartLinkJson;
+import static name.krot.smartlinks.support.SmartLinkJsonFixtures.invalidRedirectSmartLinkJson;
+import static name.krot.smartlinks.support.SmartLinkJsonFixtures.validSmartLinkJson;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.RU_REDIRECT_URL;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -45,24 +50,24 @@ class RedirectControllerTest {
 
     @Test
     void testRedirectWithMatchingRule() throws Exception {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 11, 15, 12, 0), "ru-RU", null);
+        RequestContext context = requestContext("ru-RU");
         when(requestContextFactory.from(any())).thenReturn(context);
-        when(redirectResolver.resolveRedirect("smartlink123", context)).thenReturn(URI.create("https://otus.ru/ru"));
+        when(redirectResolver.resolveRedirect(SMART_LINK_ID, context)).thenReturn(URI.create(RU_REDIRECT_URL));
 
-        mockMvc.perform(get("/s/smartlink123")
+        mockMvc.perform(get("/s/{smartLinkId}", SMART_LINK_ID)
                         .header("Accept-Language", "ru-RU"))
                 .andExpect(status().isFound())
-                .andExpect(header().string("Location", "https://otus.ru/ru"));
+                .andExpect(header().string("Location", RU_REDIRECT_URL));
     }
 
     @Test
     void testRedirectWithNoMatchingRule() throws Exception {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 11, 15, 12, 0), "en-US", null);
+        RequestContext context = requestContext("en-US");
         when(requestContextFactory.from(any())).thenReturn(context);
-        when(redirectResolver.resolveRedirect("smartlink123", context))
+        when(redirectResolver.resolveRedirect(SMART_LINK_ID, context))
                 .thenThrow(new NoMatchingRuleException("No matching rule found for this Smart Link"));
 
-        mockMvc.perform(get("/s/smartlink123")
+        mockMvc.perform(get("/s/{smartLinkId}", SMART_LINK_ID)
                         .header("Accept-Language", "en-US"))
                 .andExpect(status().isNotFound())
                 .andExpect(content().string("No matching rule found for this Smart Link"));
@@ -70,7 +75,7 @@ class RedirectControllerTest {
 
     @Test
     void testRedirectWithNonExistentSmartLink() throws Exception {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 11, 15, 12, 0), null, null);
+        RequestContext context = requestContext(null);
         when(requestContextFactory.from(any())).thenReturn(context);
         when(redirectResolver.resolveRedirect("nonexistent", context))
                 .thenThrow(new SmartLinkNotFoundException("Smart Link not found"));
@@ -82,24 +87,9 @@ class RedirectControllerTest {
 
     @Test
     void testCreateSmartLink() throws Exception {
-        String smartLinkJson = "{\n" +
-                "  \"id\": \"smartlink123\",\n" +
-                "  \"rules\": [\n" +
-                "    {\n" +
-                "      \"predicates\": [\"DateRange\", \"Language\"],\n" +
-                "      \"args\": {\n" +
-                "        \"startWith\": \"2024-11-01T00:00:00\",\n" +
-                "        \"endWith\": \"2024-12-01T00:00:00\",\n" +
-                "        \"language\": [\"ru\", \"ru-RU\"]\n" +
-                "      },\n" +
-                "      \"redirectTo\": \"https://otus.ru/ru\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-
         mockMvc.perform(post("/api/smartlinks")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(smartLinkJson))
+                        .content(validSmartLinkJson()))
                 .andExpect(status().isCreated())
                 .andExpect(content().string("Smart Link created successfully"));
 
@@ -107,47 +97,23 @@ class RedirectControllerTest {
         verify(smartLinkService, times(1)).saveSmartLink(smartLinkCaptor.capture());
 
         SmartLink capturedSmartLink = smartLinkCaptor.getValue();
-        assertEquals("smartlink123", capturedSmartLink.getId());
+        assertEquals(SMART_LINK_ID, capturedSmartLink.getId());
         assertEquals(1, capturedSmartLink.getRules().size());
     }
 
     @Test
     void testCreateSmartLinkAcceptsFallbackRule() throws Exception {
-        String smartLinkJson = "{\n" +
-                "  \"id\": \"smartlink123\",\n" +
-                "  \"rules\": [\n" +
-                "    {\n" +
-                "      \"predicates\": [],\n" +
-                "      \"args\": {},\n" +
-                "      \"redirectTo\": \"https://otus.ru/default\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-
         mockMvc.perform(post("/api/smartlinks")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(smartLinkJson))
+                        .content(fallbackSmartLinkJson()))
                 .andExpect(status().isCreated());
     }
 
     @Test
     void testCreateSmartLinkRejectsRedirectWithoutHost() throws Exception {
-        String smartLinkJson = "{\n" +
-                "  \"id\": \"smartlink123\",\n" +
-                "  \"rules\": [\n" +
-                "    {\n" +
-                "      \"predicates\": [\"Language\"],\n" +
-                "      \"args\": {\n" +
-                "        \"language\": [\"ru\"]\n" +
-                "      },\n" +
-                "      \"redirectTo\": \"https:otus.ru/no-host\"\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-
         mockMvc.perform(post("/api/smartlinks")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(smartLinkJson))
+                        .content(invalidRedirectSmartLinkJson()))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/name/krot/smartlinks/model/SmartLinkTest.java
+++ b/src/test/java/name/krot/smartlinks/model/SmartLinkTest.java
@@ -3,22 +3,20 @@ package name.krot.smartlinks.model;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.RU_REDIRECT_URL;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.fallbackRule;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SmartLinkTest {
 
     @Test
     void testSmartLinkGettersAndSetters() {
-        SmartLink smartLink = new SmartLink();
-        smartLink.setId("smartlink123");
-        assertEquals("smartlink123", smartLink.getId());
+        SmartLink smartLink = smartLink(fallbackRule(RU_REDIRECT_URL));
 
-        Rule rule = new Rule();
-        rule.setRedirectTo("https://otus.ru");
-        smartLink.setRules(Collections.singletonList(rule));
+        assertEquals(SMART_LINK_ID, smartLink.getId());
         assertEquals(1, smartLink.getRules().size());
-        assertEquals("https://otus.ru", smartLink.getRules().get(0).getRedirectTo());
+        assertEquals(RU_REDIRECT_URL, smartLink.getRules().get(0).getRedirectTo());
     }
 }

--- a/src/test/java/name/krot/smartlinks/predicate/DateRangePredicateTest.java
+++ b/src/test/java/name/krot/smartlinks/predicate/DateRangePredicateTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.HashMap;
-import java.util.Map;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.dateRangeArguments;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContextAt;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -17,50 +17,43 @@ class DateRangePredicateTest {
 
     @Test
     void testDateWithinRange() {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 11, 15, 12, 0), null, null);
+        RequestContext context = requestContextAt(LocalDateTime.of(2024, 11, 15, 12, 0));
 
-        Map<String, Object> args = new HashMap<>();
-        args.put("startWith", "2024-11-01T00:00:00");
-        args.put("endWith", "2024-12-01T00:00:00");
-
-        boolean result = dateRangePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = dateRangePredicate.evaluate(
+                context,
+                dateRangeArguments("2024-11-01T00:00:00", "2024-12-01T00:00:00")
+        );
         assertTrue(result);
     }
 
     @Test
     void testDateBeforeRange() {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 10, 31, 23, 59), null, null);
+        RequestContext context = requestContextAt(LocalDateTime.of(2024, 10, 31, 23, 59));
 
-        Map<String, Object> args = new HashMap<>();
-        args.put("startWith", "2024-11-01T00:00:00");
-        args.put("endWith", "2024-12-01T00:00:00");
-
-        boolean result = dateRangePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = dateRangePredicate.evaluate(
+                context,
+                dateRangeArguments("2024-11-01T00:00:00", "2024-12-01T00:00:00")
+        );
         assertFalse(result);
     }
 
     @Test
     void testDateAfterRange() {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 12, 1, 0, 1), null, null);
+        RequestContext context = requestContextAt(LocalDateTime.of(2024, 12, 1, 0, 1));
 
-        Map<String, Object> args = new HashMap<>();
-        args.put("startWith", "2024-11-01T00:00:00");
-        args.put("endWith", "2024-12-01T00:00:00");
-
-        boolean result = dateRangePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = dateRangePredicate.evaluate(
+                context,
+                dateRangeArguments("2024-11-01T00:00:00", "2024-12-01T00:00:00")
+        );
         assertFalse(result);
     }
 
     @Test
     void testDateRangePredicateWithInvalidArgs() {
-        RequestContext context = new RequestContext(LocalDateTime.now(), null, null);
-
-        Map<String, Object> args = new HashMap<>();
-        args.put("startWith", "invalid date");
-        args.put("endWith", "invalid date");
+        RequestContext context = requestContextAt(LocalDateTime.now());
 
         assertThrows(DateTimeParseException.class, () -> {
-            dateRangePredicate.evaluate(context, new PredicateArguments(args));
+            dateRangePredicate.evaluate(context, dateRangeArguments("invalid date", "invalid date"));
         });
     }
 }

--- a/src/test/java/name/krot/smartlinks/predicate/DeviceTypePredicateTest.java
+++ b/src/test/java/name/krot/smartlinks/predicate/DeviceTypePredicateTest.java
@@ -2,12 +2,11 @@ package name.krot.smartlinks.predicate;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.deviceArguments;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -18,57 +17,43 @@ class DeviceTypePredicateTest {
 
     @Test
     void testMobileDevice() {
-        RequestContext context = new RequestContext(
-                LocalDateTime.now(),
+        RequestContext context = requestContext(
                 null,
                 "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5_1 like Mac OS X)"
         );
 
-        Map<String, Object> args = new HashMap<>();
-        args.put("devices", List.of("Mobile"));
-
-        boolean result = deviceTypePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = deviceTypePredicate.evaluate(context, deviceArguments(List.of("Mobile")));
         assertTrue(result);
     }
 
     @Test
     void testDesktopDevice() {
-        RequestContext context = new RequestContext(
-                LocalDateTime.now(),
+        RequestContext context = requestContext(
                 null,
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
         );
 
-        Map<String, Object> args = new HashMap<>();
-        args.put("devices", List.of("Desktop"));
-
-        boolean result = deviceTypePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = deviceTypePredicate.evaluate(context, deviceArguments(List.of("Desktop")));
         assertTrue(result);
     }
 
     @Test
     void testUnknownDevice() {
-        RequestContext context = new RequestContext(LocalDateTime.now(), null, null);
-
-        Map<String, Object> args = new HashMap<>();
-        args.put("devices", Arrays.asList("Mobile", "Desktop"));
-
-        boolean result = deviceTypePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = deviceTypePredicate.evaluate(
+                requestContext(null, null),
+                deviceArguments(Arrays.asList("Mobile", "Desktop"))
+        );
         assertFalse(result);
     }
 
     @Test
     void testDeviceNotInList() {
-        RequestContext context = new RequestContext(
-                LocalDateTime.now(),
+        RequestContext context = requestContext(
                 null,
                 "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
         );
 
-        Map<String, Object> args = new HashMap<>();
-        args.put("devices", List.of("Mobile"));
-
-        boolean result = deviceTypePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = deviceTypePredicate.evaluate(context, deviceArguments(List.of("Mobile")));
         assertFalse(result);
     }
 }

--- a/src/test/java/name/krot/smartlinks/predicate/LanguagePredicateTest.java
+++ b/src/test/java/name/krot/smartlinks/predicate/LanguagePredicateTest.java
@@ -2,12 +2,11 @@ package name.krot.smartlinks.predicate;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.languageArguments;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -18,34 +17,28 @@ class LanguagePredicateTest {
 
     @Test
     void testLanguageMatches() {
-        RequestContext context = new RequestContext(LocalDateTime.now(), "ru-RU", null);
-
-        Map<String, Object> args = new HashMap<>();
-        args.put("language", Arrays.asList("ru", "ru-RU"));
-
-        boolean result = languagePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = languagePredicate.evaluate(
+                requestContext("ru-RU"),
+                languageArguments(Arrays.asList("ru", "ru-RU"))
+        );
         assertTrue(result);
     }
 
     @Test
     void testLanguageDoesNotMatch() {
-        RequestContext context = new RequestContext(LocalDateTime.now(), "en-US", null);
-
-        Map<String, Object> args = new HashMap<>();
-        args.put("language", Arrays.asList("ru", "ru-RU"));
-
-        boolean result = languagePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = languagePredicate.evaluate(
+                requestContext("en-US"),
+                languageArguments(Arrays.asList("ru", "ru-RU"))
+        );
         assertFalse(result);
     }
 
     @Test
     void testLanguagePredicateWithEmptyLanguageList() {
-        RequestContext context = new RequestContext(LocalDateTime.now(), "en-US", null);
-
-        Map<String, Object> args = new HashMap<>();
-        args.put("language", Collections.emptyList());
-
-        boolean result = languagePredicate.evaluate(context, new PredicateArguments(args));
+        boolean result = languagePredicate.evaluate(
+                requestContext("en-US"),
+                languageArguments(Collections.emptyList())
+        );
         assertFalse(result);
     }
 }

--- a/src/test/java/name/krot/smartlinks/repository/SmartLinkRepositoryDockerTest.java
+++ b/src/test/java/name/krot/smartlinks/repository/SmartLinkRepositoryDockerTest.java
@@ -15,7 +15,10 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -24,33 +27,31 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @Import(SmartLinkRepositoryDockerTest.TestConfig.class)
 class SmartLinkRepositoryDockerTest {
 
+    private static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:7.0.5-alpine");
+
     @Container
-    static RedisContainer redisContainer = new RedisContainer("redis:7.0.5-alpine");
+    static RedisContainer redisContainer = new RedisContainer(REDIS_IMAGE);
 
     @Autowired
     private SmartLinkRepository smartLinkRepository;
 
-    @Autowired
-    private RedisTemplate<String, Object> redisTemplate;
-
     @DynamicPropertySource
     static void redisProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.redis.host", redisContainer::getHost);
-        registry.add("spring.redis.port", redisContainer::getFirstMappedPort);
-        registry.add("spring.redis.password", () -> "password");
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", redisContainer::getFirstMappedPort);
+        registry.add("spring.data.redis.password", () -> "password");
     }
 
     @Test
     void testSaveAndFindById() {
-        SmartLink smartLink = new SmartLink();
-        smartLink.setId("smartlink123");
+        SmartLink smartLink = smartLink();
 
         smartLinkRepository.save(smartLink);
 
-        SmartLink result = smartLinkRepository.findById("smartlink123").orElse(null);
+        SmartLink result = smartLinkRepository.findById(SMART_LINK_ID).orElse(null);
 
         assertNotNull(result);
-        assertEquals("smartlink123", result.getId());
+        assertEquals(SMART_LINK_ID, result.getId());
     }
 
     @TestConfiguration

--- a/src/test/java/name/krot/smartlinks/service/AllPredicatesRuleEvaluatorTest.java
+++ b/src/test/java/name/krot/smartlinks/service/AllPredicatesRuleEvaluatorTest.java
@@ -7,12 +7,12 @@ import name.krot.smartlinks.predicate.PredicateFactory;
 import name.krot.smartlinks.predicate.RequestContext;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.RU_REDIRECT_URL;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.rule;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,8 +28,8 @@ class AllPredicatesRuleEvaluatorTest {
 
     @Test
     void matchesWhenAllPredicatesMatch() {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 11, 15, 12, 0), "ru-RU", null);
-        Rule rule = rule(Arrays.asList("DateRange", "Language"));
+        RequestContext context = requestContext("ru-RU");
+        Rule rule = ruleWithPredicates(Arrays.asList("DateRange", "Language"));
 
         when(predicateFactory.createPredicate("DateRange")).thenReturn(dateRangePredicate);
         when(predicateFactory.createPredicate("Language")).thenReturn(languagePredicate);
@@ -41,8 +41,8 @@ class AllPredicatesRuleEvaluatorTest {
 
     @Test
     void doesNotMatchWhenAnyPredicateFails() {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 11, 15, 12, 0), "en-US", null);
-        Rule rule = rule(Arrays.asList("DateRange", "Language"));
+        RequestContext context = requestContext("en-US");
+        Rule rule = ruleWithPredicates(Arrays.asList("DateRange", "Language"));
 
         when(predicateFactory.createPredicate("DateRange")).thenReturn(dateRangePredicate);
         when(predicateFactory.createPredicate("Language")).thenReturn(languagePredicate);
@@ -54,21 +54,12 @@ class AllPredicatesRuleEvaluatorTest {
 
     @Test
     void matchesFallbackRuleWithoutPredicates() {
-        RequestContext context = new RequestContext(LocalDateTime.of(2024, 11, 15, 12, 0), "en-US", null);
+        RequestContext context = requestContext("en-US");
 
-        assertTrue(evaluator.matches(rule(List.of()), context));
+        assertTrue(evaluator.matches(ruleWithPredicates(List.of()), context));
     }
 
-    private static Rule rule(List<String> predicates) {
-        Map<String, Object> args = new HashMap<>();
-        args.put("startWith", "2024-11-01T00:00:00");
-        args.put("endWith", "2024-12-01T00:00:00");
-        args.put("language", Arrays.asList("ru", "ru-RU"));
-
-        Rule rule = new Rule();
-        rule.setPredicates(predicates);
-        rule.setArgs(args);
-        rule.setRedirectTo("https://otus.ru/ru");
-        return rule;
+    private static Rule ruleWithPredicates(List<String> predicates) {
+        return rule(predicates, RU_REDIRECT_URL);
     }
 }

--- a/src/test/java/name/krot/smartlinks/service/RuleBasedRedirectResolverTest.java
+++ b/src/test/java/name/krot/smartlinks/service/RuleBasedRedirectResolverTest.java
@@ -10,10 +10,13 @@ import name.krot.smartlinks.predicate.RequestContext;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.RU_REDIRECT_URL;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -32,22 +35,21 @@ class RuleBasedRedirectResolverTest {
 
     @Test
     void resolvesRedirectForExistingSmartLink() {
-        SmartLink smartLink = new SmartLink();
-        smartLink.setId("smartlink123");
-        RequestContext context = new RequestContext(LocalDateTime.now(), "ru-RU", null);
-        URI redirectUri = URI.create("https://otus.ru/ru");
+        SmartLink smartLink = smartLink();
+        RequestContext context = requestContext("ru-RU");
+        URI redirectUri = URI.create(RU_REDIRECT_URL);
         List<RedirectCommand> commands = List.of(ignored -> Optional.of(redirectUri));
 
-        when(smartLinkService.findSmartLinkById("smartlink123")).thenReturn(Optional.of(smartLink));
+        when(smartLinkService.findSmartLinkById(SMART_LINK_ID)).thenReturn(Optional.of(smartLink));
         when(redirectCommandFactory.createCommands(smartLink)).thenReturn(commands);
         when(redirectCommandChain.execute(commands, context)).thenReturn(Optional.of(redirectUri));
 
-        assertEquals(redirectUri, resolver.resolveRedirect("smartlink123", context));
+        assertEquals(redirectUri, resolver.resolveRedirect(SMART_LINK_ID, context));
     }
 
     @Test
     void throwsWhenSmartLinkDoesNotExist() {
-        RequestContext context = new RequestContext(LocalDateTime.now(), null, null);
+        RequestContext context = requestContext(null);
         when(smartLinkService.findSmartLinkById("missing")).thenReturn(Optional.empty());
 
         assertThrows(SmartLinkNotFoundException.class, () -> resolver.resolveRedirect("missing", context));
@@ -55,14 +57,13 @@ class RuleBasedRedirectResolverTest {
 
     @Test
     void throwsWhenNoRuleMatches() {
-        SmartLink smartLink = new SmartLink();
-        smartLink.setId("smartlink123");
-        RequestContext context = new RequestContext(LocalDateTime.now(), "en-US", null);
+        SmartLink smartLink = smartLink();
+        RequestContext context = requestContext("en-US");
 
-        when(smartLinkService.findSmartLinkById("smartlink123")).thenReturn(Optional.of(smartLink));
+        when(smartLinkService.findSmartLinkById(SMART_LINK_ID)).thenReturn(Optional.of(smartLink));
         when(redirectCommandFactory.createCommands(smartLink)).thenReturn(List.of());
         when(redirectCommandChain.execute(List.of(), context)).thenReturn(Optional.empty());
 
-        assertThrows(NoMatchingRuleException.class, () -> resolver.resolveRedirect("smartlink123", context));
+        assertThrows(NoMatchingRuleException.class, () -> resolver.resolveRedirect(SMART_LINK_ID, context));
     }
 }

--- a/src/test/java/name/krot/smartlinks/service/RuleRedirectUriResolverTest.java
+++ b/src/test/java/name/krot/smartlinks/service/RuleRedirectUriResolverTest.java
@@ -1,8 +1,8 @@
 package name.krot.smartlinks.service;
 
-import name.krot.smartlinks.model.Rule;
 import org.junit.jupiter.api.Test;
 
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.fallbackRule;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -12,17 +12,11 @@ class RuleRedirectUriResolverTest {
 
     @Test
     void resolvesValidRedirectUrl() {
-        assertEquals("https://otus.ru/ru", resolver.resolve(rule(" https://otus.ru/ru ")).orElseThrow().toString());
+        assertEquals("https://otus.ru/ru", resolver.resolve(fallbackRule(" https://otus.ru/ru ")).orElseThrow().toString());
     }
 
     @Test
     void returnsEmptyForInvalidRedirectUrl() {
-        assertTrue(resolver.resolve(rule("https:otus.ru/no-host")).isEmpty());
-    }
-
-    private static Rule rule(String redirectTo) {
-        Rule rule = new Rule();
-        rule.setRedirectTo(redirectTo);
-        return rule;
+        assertTrue(resolver.resolve(fallbackRule("https:otus.ru/no-host")).isEmpty());
     }
 }

--- a/src/test/java/name/krot/smartlinks/service/SmartLinkServiceTest.java
+++ b/src/test/java/name/krot/smartlinks/service/SmartLinkServiceTest.java
@@ -5,14 +5,18 @@ import name.krot.smartlinks.repository.SmartLinkRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class SmartLinkServiceTest {
 
     @InjectMocks
@@ -21,27 +25,21 @@ class SmartLinkServiceTest {
     @Mock
     private SmartLinkRepository smartLinkRepository;
 
-    public SmartLinkServiceTest() {
-        MockitoAnnotations.openMocks(this);
-    }
-
     @Test
     void testGetSmartLinkById() {
-        SmartLink smartLink = new SmartLink();
-        smartLink.setId("smartlink123");
+        SmartLink smartLink = smartLink();
 
-        when(smartLinkRepository.findById("smartlink123")).thenReturn(java.util.Optional.of(smartLink));
+        when(smartLinkRepository.findById(SMART_LINK_ID)).thenReturn(java.util.Optional.of(smartLink));
 
-        SmartLink result = smartLinkService.findSmartLinkById("smartlink123").orElseThrow();
+        SmartLink result = smartLinkService.findSmartLinkById(SMART_LINK_ID).orElseThrow();
 
         assertNotNull(result);
-        assertEquals("smartlink123", result.getId());
+        assertEquals(SMART_LINK_ID, result.getId());
     }
 
     @Test
     void testSaveSmartLink() {
-        SmartLink smartLink = new SmartLink();
-        smartLink.setId("smartlink123");
+        SmartLink smartLink = smartLink();
 
         smartLinkService.saveSmartLink(smartLink);
 

--- a/src/test/java/name/krot/smartlinks/support/SmartLinkJsonFixtures.java
+++ b/src/test/java/name/krot/smartlinks/support/SmartLinkJsonFixtures.java
@@ -1,0 +1,58 @@
+package name.krot.smartlinks.support;
+
+public final class SmartLinkJsonFixtures {
+
+    private SmartLinkJsonFixtures() {
+    }
+
+    public static String validSmartLinkJson() {
+        return """
+                {
+                  "id": "smartlink123",
+                  "rules": [
+                    {
+                      "predicates": ["DateRange", "Language"],
+                      "args": {
+                        "startWith": "2024-11-01T00:00:00",
+                        "endWith": "2024-12-01T00:00:00",
+                        "language": ["ru", "ru-RU"]
+                      },
+                      "redirectTo": "https://otus.ru/ru"
+                    }
+                  ]
+                }
+                """;
+    }
+
+    public static String fallbackSmartLinkJson() {
+        return """
+                {
+                  "id": "smartlink123",
+                  "rules": [
+                    {
+                      "predicates": [],
+                      "args": {},
+                      "redirectTo": "https://otus.ru/default"
+                    }
+                  ]
+                }
+                """;
+    }
+
+    public static String invalidRedirectSmartLinkJson() {
+        return """
+                {
+                  "id": "smartlink123",
+                  "rules": [
+                    {
+                      "predicates": ["Language"],
+                      "args": {
+                        "language": ["ru"]
+                      },
+                      "redirectTo": "https:otus.ru/no-host"
+                    }
+                  ]
+                }
+                """;
+    }
+}

--- a/src/test/java/name/krot/smartlinks/support/SmartLinksTestFixtures.java
+++ b/src/test/java/name/krot/smartlinks/support/SmartLinksTestFixtures.java
@@ -1,0 +1,81 @@
+package name.krot.smartlinks.support;
+
+import name.krot.smartlinks.model.Rule;
+import name.krot.smartlinks.model.SmartLink;
+import name.krot.smartlinks.predicate.PredicateArguments;
+import name.krot.smartlinks.predicate.RequestContext;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class SmartLinksTestFixtures {
+
+    public static final String SMART_LINK_ID = "smartlink123";
+    public static final String RU_REDIRECT_URL = "https://otus.ru/ru";
+    public static final String DEFAULT_REDIRECT_URL = "https://otus.ru/default";
+    public static final LocalDateTime REQUEST_TIME = LocalDateTime.of(2024, 11, 15, 12, 0);
+
+    private SmartLinksTestFixtures() {
+    }
+
+    public static SmartLink smartLink(Rule... rules) {
+        SmartLink smartLink = new SmartLink();
+        smartLink.setId(SMART_LINK_ID);
+        smartLink.setRules(Arrays.asList(rules));
+        return smartLink;
+    }
+
+    public static Rule rule(List<String> predicates, String redirectTo) {
+        return rule(predicates, redirectTo, defaultPredicateArgumentsMap());
+    }
+
+    public static Rule rule(List<String> predicates, String redirectTo, Map<String, Object> args) {
+        Rule rule = new Rule();
+        rule.setPredicates(predicates);
+        rule.setArgs(args);
+        rule.setRedirectTo(redirectTo);
+        return rule;
+    }
+
+    public static Rule fallbackRule(String redirectTo) {
+        return rule(List.of(), redirectTo, Map.of());
+    }
+
+    public static RequestContext requestContext(String acceptLanguage) {
+        return new RequestContext(REQUEST_TIME, acceptLanguage, null);
+    }
+
+    public static RequestContext requestContext(String acceptLanguage, String userAgent) {
+        return new RequestContext(REQUEST_TIME, acceptLanguage, userAgent);
+    }
+
+    public static RequestContext requestContextAt(LocalDateTime requestTime) {
+        return new RequestContext(requestTime, null, null);
+    }
+
+    public static PredicateArguments languageArguments(List<String> languages) {
+        return new PredicateArguments(Map.of("language", languages));
+    }
+
+    public static PredicateArguments deviceArguments(List<String> devices) {
+        return new PredicateArguments(Map.of("devices", devices));
+    }
+
+    public static PredicateArguments dateRangeArguments(String start, String end) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("startWith", start);
+        args.put("endWith", end);
+        return new PredicateArguments(args);
+    }
+
+    public static Map<String, Object> defaultPredicateArgumentsMap() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("startWith", "2024-11-01T00:00:00");
+        args.put("endWith", "2024-12-01T00:00:00");
+        args.put("language", Arrays.asList("ru", "ru-RU"));
+        return args;
+    }
+}


### PR DESCRIPTION
## What changed

- Added dedicated test fixtures for SmartLink domain objects, request contexts, predicate arguments, and MVC JSON payloads.
- Refactored controller, predicate, command, service, model, and repository tests to use fixtures instead of duplicating setup.
- Replaced manual Mockito initialization with `MockitoExtension` in the service test.
- Kept tests free of explicit `if` / `switch` branching.
- Cleaned Redis repository integration test setup.

## Validation

- `./gradlew.bat build`
- `rg -n "\\bif\\b|\\bswitch\\b" src\\main\\java\\name\\krot\\smartlinks src\\test\\java\\name\\krot\\smartlinks` returned no matches.