### PR TITLE
Document cache key inventory

### DIFF
--- a/docs/cache/cache-key-inventory.md
+++ b/docs/cache/cache-key-inventory.md
@@ -1,0 +1,9 @@
+# Cache Key Inventory
+
+SmartLinks uses cache entries around redirects, metadata lookup, and route decisions.
+
+- Keep key names stable across deploys.
+- Include tenant or namespace values where rules may overlap.
+- Prefer short TTLs for dynamic routing outcomes.
+
+Review cadence: update when the related workflow changes.


### PR DESCRIPTION
Adds focused SmartLinks maintenance documentation.

Verification: documentation-only change.