### PR TITLE
Add local runbook

### DIFF
--- a/docs/operations/local-runbook.md
+++ b/docs/operations/local-runbook.md
@@ -1,0 +1,9 @@
+# Local Runbook
+
+Use this runbook for local SmartLinks maintenance.
+
+- Start dependencies before the application process.
+- Keep environment values outside committed files.
+- Capture command output when investigating routing changes.
+
+Review cadence: update when the related workflow changes.


### PR DESCRIPTION
Adds focused SmartLinks maintenance documentation.

Verification: documentation-only change.