### PR TITLE
Document service boundaries

### DIFF
--- a/docs/architecture/service-boundaries.md
+++ b/docs/architecture/service-boundaries.md
@@ -1,0 +1,9 @@
+# Service Boundaries
+
+Service boundaries keep SmartLinks changes scoped.
+
+- Redirect resolution belongs in the application service.
+- Cache storage belongs behind the Redis integration.
+- Deployment concerns belong in manifests and operational docs.
+
+Review cadence: update when the related workflow changes.


### PR DESCRIPTION
Adds focused SmartLinks maintenance documentation.

Verification: documentation-only change.