### PR TITLE
Harden smart link integrity and runtime handling

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -68,7 +68,7 @@ Version 2 applies four targeted optimizations; version 3 adds an L1 cache:
 | **Shenandoah GC** | `-XX:+UseShenandoahGC` in the Docker ENTRYPOINT (Ubuntu JRE — glibc is required for Shenandoah) |
 | **Redis JSON instead of JDK serialization** | `StringRedisTemplate` + `JsonMapper` (Jackson 3, `tools.jackson`) + individual `sl:<id>` keys instead of a single mega-hash |
 | **Lettuce connection pool** | `spring.data.redis.lettuce.pool.enabled=true`, 16 connections — virtual threads no longer serialize through a single Lettuce connection |
-| **Caffeine L1 cache** | `Cache<String, SmartLink>` in `RedisSmartLinkRepository` — 10,000 entries, `expireAfterAccess=10m`; `save()` writes to both levels atomically |
+| **Caffeine L1 cache** | `Cache<String, String>` stores immutable JSON instead of externally mutable objects; 10,000 entries, `expireAfterAccess=10m`. Creation uses atomic Redis `SETNX`, so concurrent requests cannot overwrite a write-once link |
 
 Spring Boot 4.1 does not publish `spring-boot-starter-undertow` — Undertow was removed from the distribution.
 Virtual threads with Tomcat 11 achieve equal or better results.
@@ -174,7 +174,7 @@ Previous result (before virtual threads): ≥ 4,500 users → 0.14 % HTTP 5xx (T
 
 **Redis JSON serialization + Lettuce pool** cut CPU and wire payload. JDK serialization replaced by `StringRedisTemplate` + `JsonMapper`, individual `sl:<id>` keys instead of a single hash. Combined with the pool (16 connections), eliminates serialization through a single connection under high concurrency.
 
-**Caffeine L1 cache** is the primary second-stage driver. SmartLinks are write-once, read-many: 50 hot keys fit in Caffeine and are populated on `save()` and on the first Redis miss. At 200 concurrent GET users, Redis saturation was the bottleneck; the cache removes it entirely — p99 drops from 881 ms to 174 ms (−80 %). In this Docker-local benchmark (Redis sibling container, ~1 ms RTT) the gain at moderate load is smaller (LoadSim GET p99: 79→66 ms, −17 %). In production, where Redis is a separate host (10–50 ms), the effect is proportionally larger.
+**Caffeine L1 cache** is the primary second-stage driver. SmartLinks are write-once, read-many: 50 hot keys fit in Caffeine and are populated after successful creation and on the first Redis miss. At 200 concurrent GET users, Redis saturation was the bottleneck; the cache removes it entirely — p99 drops from 881 ms to 174 ms (−80 %). In this Docker-local benchmark (Redis sibling container, ~1 ms RTT) the gain at moderate load is smaller (LoadSim GET p99: 79→66 ms, −17 %). In production, where Redis is a separate host (10–50 ms), the effect is proportionally larger.
 
 **SpikeSim p99** increased from 125 ms to 223 ms while maintaining zero errors. The cause is a side effect of optimization: faster per-request processing raises the virtual-user cycle rate, concentrating more Redis operations into the 10× spike window. Throughput still rose 11 %.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ API документация доступна на `/swagger-ui/index.html` по
 | **Shenandoah GC** | `-XX:+UseShenandoahGC` в Docker ENTRYPOINT (Ubuntu JRE — glibc обязателен для Shenandoah) |
 | **Redis JSON вместо JDK serialization** | `StringRedisTemplate` + `JsonMapper` (Jackson 3, `tools.jackson`) + индивидуальные ключи `sl:<id>` вместо единого хэша |
 | **Lettuce connection pool** | `spring.data.redis.lettuce.pool.enabled=true`, 16 соединений — виртуальные потоки не блокируются на одном Lettuce-соединении |
-| **Caffeine L1-кэш** | `Cache<String, SmartLink>` в `RedisSmartLinkRepository` — 10 000 записей, `expireAfterAccess=10m`; `save()` записывает в оба уровня сразу |
+| **Caffeine L1-кэш** | `Cache<String, String>` хранит неизменяемый JSON, а не выдаваемые наружу mutable-объекты; 10 000 записей, `expireAfterAccess=10m`. Создание выполняется атомарным Redis `SETNX`, поэтому write-once ссылка не перезаписывается при гонке |
 
 Spring Boot 4.1 не публикует `spring-boot-starter-undertow` — Undertow убран из дистрибутива.
 Virtual threads с Tomcat 11 дают те же или лучшие результаты.
@@ -174,7 +174,7 @@ Caffeine устраняет Redis-сатурацию: при 200 пользов�
 
 **Redis JSON serialization + Lettuce pool** — снижение CPU и payload. JDK-сериализация заменена на `StringRedisTemplate` + `JsonMapper`, индивидуальные ключи `sl:<id>` вместо единого хэша. Совместно с пулом 16 соединений устраняет очередь через одно Lettuce-соединение при высоком параллелизме.
 
-**Caffeine L1-кэш** — главная оптимизация второго этапа. SmartLinks write-once, read-many: 50 горячих ключей помещаются в Caffeine при `save()` и при первом промахе Redis. При 200 конкурентных GET-пользователях Redis-сатурация была узким местом; кэш устраняет её полностью — p99 падает с 881 мс до 174 мс (−80 %). В Docker-локальном бенчмарке (Redis-контейнер ~1 мс RTT) Caffeine даёт более скромный результат на умеренной нагрузке (LoadSim GET p99: 79→66 мс, −17 %). В production, где Redis — отдельный хост (10–50 мс), эффект кратно выше.
+**Caffeine L1-кэш** — главная оптимизация второго этапа. SmartLinks write-once, read-many: 50 горячих ключей помещаются в Caffeine после успешного создания и при первом промахе Redis. При 200 конкурентных GET-пользователях Redis-сатурация была узким местом; кэш устраняет её полностью — p99 падает с 881 мс до 174 мс (−80 %). В Docker-локальном бенчмарке (Redis-контейнер ~1 мс RTT) Caffeine даёт более скромный результат на умеренной нагрузке (LoadSim GET p99: 79→66 мс, −17 %). В production, где Redis — отдельный хост (10–50 мс), эффект кратно выше.
 
 **SpikeSim p99** вырос с 125 мс до 223 мс при сохранении 0 ошибок. Причина — побочный эффект оптимизации: более быстрые запросы повышают частоту цикла виртуальных пользователей, что увеличивает нагрузку на Redis во время пика (10×). Throughput при этом вырос на 11 %.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,14 @@ services:
     container_name: redis
     image: redis:8.2-alpine@sha256:94589dc90eb8b7eb920f3a9a6d85657e73fd20db61410719500b9c5ba0548d9a
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
   app:
     build:
       context: .
@@ -26,4 +31,5 @@ services:
       - SPRING_DATA_REDIS_PORT=6379
     restart: always
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -22,15 +22,19 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: "prod"
+            - name: SPRING_DATA_REDIS_HOST
+              value: "redis"
+            - name: SPRING_DATA_REDIS_PORT
+              value: "6379"
           readinessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/readiness
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /actuator/health
+              path: /actuator/health/liveness
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -2,8 +2,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: smart-links-ingress
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
     - host: smart-links.local

--- a/k8s/redis.yaml
+++ b/k8s/redis.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: smart-links-redis
+spec:
+  type: ClusterIP
+  selector:
+    app: smart-links-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: smart-links-redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smart-links-redis
+  template:
+    metadata:
+      labels:
+        app: smart-links-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:8.2-alpine@sha256:94589dc90eb8b7eb920f3a9a6d85657e73fd20db61410719500b9c5ba0548d9a
+          args: ["redis-server", "--appendonly", "yes"]
+          ports:
+            - name: redis
+              containerPort: 6379
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: smart-links-redis-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: smart-links-redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: smart-links
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: smart-links
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - port: 80
       targetPort: 8080

--- a/src/gatling/java/name/krot/smartlinks/load/BreakSim.java
+++ b/src/gatling/java/name/krot/smartlinks/load/BreakSim.java
@@ -27,26 +27,26 @@ public class BreakSim extends SmartLinksSimulation {
 
     {
         setUp(
-                seedLinks.injectOpen(atOnceUsers(1)),
+                seedLinks.injectOpen(atOnceUsers(1)).andThen(
+                        redirectLoop.injectClosed(
+                                rampConcurrentUsers(0).to(500).during(RAMP),
+                                constantConcurrentUsers(500).during(STEP),
 
-                redirectLoop.injectClosed(
-                        rampConcurrentUsers(0).to(500).during(RAMP),
-                        constantConcurrentUsers(500).during(STEP),
+                                rampConcurrentUsers(500).to(1000).during(RAMP),
+                                constantConcurrentUsers(1000).during(STEP),
 
-                        rampConcurrentUsers(500).to(1000).during(RAMP),
-                        constantConcurrentUsers(1000).during(STEP),
+                                rampConcurrentUsers(1000).to(2000).during(RAMP),
+                                constantConcurrentUsers(2000).during(STEP),
 
-                        rampConcurrentUsers(1000).to(2000).during(RAMP),
-                        constantConcurrentUsers(2000).during(STEP),
+                                rampConcurrentUsers(2000).to(3000).during(RAMP),
+                                constantConcurrentUsers(3000).during(STEP),
 
-                        rampConcurrentUsers(2000).to(3000).during(RAMP),
-                        constantConcurrentUsers(3000).during(STEP),
+                                rampConcurrentUsers(3000).to(4000).during(RAMP),
+                                constantConcurrentUsers(4000).during(STEP),
 
-                        rampConcurrentUsers(3000).to(4000).during(RAMP),
-                        constantConcurrentUsers(4000).during(STEP),
-
-                        rampConcurrentUsers(4000).to(5000).during(RAMP),
-                        constantConcurrentUsers(5000).during(STEP)
+                                rampConcurrentUsers(4000).to(5000).during(RAMP),
+                                constantConcurrentUsers(5000).during(STEP)
+                        )
                 )
         )
                 .protocols(protocol)

--- a/src/gatling/java/name/krot/smartlinks/load/LoadSim.java
+++ b/src/gatling/java/name/krot/smartlinks/load/LoadSim.java
@@ -15,8 +15,7 @@ import static io.gatling.javaapi.core.CoreDsl.*;
  *   Redirect users: 0 → 40  over 2 min, hold 5 min, drain 1 min
  *   Create  users: 0 → 10  over 2 min, hold 5 min, drain 1 min
  *
- * Seed (atOnceUsers 1) runs in parallel; completes in ~1 s — well before
- * the 2-min ramp reaches meaningful load.
+ * Seed (atOnceUsers 1) completes before the read/write populations start.
  *
  * Assertions: p95 < 100 ms (GET), p99 < 300 ms (GET), error rate < 1 %.
  *
@@ -26,18 +25,17 @@ public class LoadSim extends SmartLinksSimulation {
 
     {
         setUp(
-                seedLinks.injectOpen(atOnceUsers(1)),
-
-                redirectLoop.injectClosed(
-                        rampConcurrentUsers(0).to(40).during(Duration.ofMinutes(2)),
-                        constantConcurrentUsers(40).during(Duration.ofMinutes(5)),
-                        rampConcurrentUsers(40).to(0).during(Duration.ofMinutes(1))
-                ),
-
-                createLoop.injectClosed(
-                        rampConcurrentUsers(0).to(10).during(Duration.ofMinutes(2)),
-                        constantConcurrentUsers(10).during(Duration.ofMinutes(5)),
-                        rampConcurrentUsers(10).to(0).during(Duration.ofMinutes(1))
+                seedLinks.injectOpen(atOnceUsers(1)).andThen(
+                        redirectLoop.injectClosed(
+                                rampConcurrentUsers(0).to(40).during(Duration.ofMinutes(2)),
+                                constantConcurrentUsers(40).during(Duration.ofMinutes(5)),
+                                rampConcurrentUsers(40).to(0).during(Duration.ofMinutes(1))
+                        ),
+                        createLoop.injectClosed(
+                                rampConcurrentUsers(0).to(10).during(Duration.ofMinutes(2)),
+                                constantConcurrentUsers(10).during(Duration.ofMinutes(5)),
+                                rampConcurrentUsers(10).to(0).during(Duration.ofMinutes(1))
+                        )
                 )
         )
                 .protocols(protocol)

--- a/src/gatling/java/name/krot/smartlinks/load/SmartLinksSimulation.java
+++ b/src/gatling/java/name/krot/smartlinks/load/SmartLinksSimulation.java
@@ -20,6 +20,8 @@ public abstract class SmartLinksSimulation extends Simulation {
             System.getProperty("baseUrl", "http://localhost:8090");
 
     static final int LINK_POOL_SIZE = 50;
+    private static final String LINK_POOL_PREFIX = "load-lnk-" +
+            UUID.randomUUID().toString().replace("-", "");
 
     protected final HttpProtocolBuilder protocol = http
             .baseUrl(BASE_URL)
@@ -29,7 +31,7 @@ public abstract class SmartLinksSimulation extends Simulation {
 
     protected final FeederBuilder<Object> linkIdFeeder = listFeeder(
             IntStream.rangeClosed(1, LINK_POOL_SIZE)
-                    .mapToObj(i -> Map.<String, Object>of("linkId", String.format("load-lnk-%03d", i)))
+                    .mapToObj(i -> Map.<String, Object>of("linkId", linkId(i)))
                     .collect(Collectors.toList())
     ).random();
 
@@ -56,7 +58,7 @@ public abstract class SmartLinksSimulation extends Simulation {
     protected final ScenarioBuilder seedLinks = scenario("Seed SmartLinks")
             .exec(repeat(LINK_POOL_SIZE, "i").on(
                     exec(session ->
-                            session.set("seedId", String.format("load-lnk-%03d", session.getInt("i") + 1))
+                            session.set("seedId", linkId(session.getInt("i") + 1))
                     ).exec(http("POST seed link")
                             .post("/api/smartlinks")
                             .body(StringBody(session -> buildSeedJson(session.getString("seedId"))))
@@ -96,6 +98,10 @@ public abstract class SmartLinksSimulation extends Simulation {
                                     """.formatted(session.getString("newId"))))
                             .check(status().is(201)))
             );
+
+    private static String linkId(int index) {
+        return "%s-%03d".formatted(LINK_POOL_PREFIX, index);
+    }
 
     private static String buildSeedJson(String id) {
         return """

--- a/src/gatling/java/name/krot/smartlinks/load/SmokeSim.java
+++ b/src/gatling/java/name/krot/smartlinks/load/SmokeSim.java
@@ -8,8 +8,7 @@ import static io.gatling.javaapi.core.CoreDsl.*;
  * Smoke test: sanity check at minimal load (5 concurrent users, ~70 s).
  *
  * Uses the closed injection model so behaviour stays consistent with the
- * other simulations.  Seed scenario runs in parallel and completes well
- * before the ramp reaches any real concurrency.
+ * other simulations. The seed scenario completes before redirect traffic starts.
  *
  * Assertions: zero errors, p95 < 500 ms.
  *
@@ -19,11 +18,11 @@ public class SmokeSim extends SmartLinksSimulation {
 
     {
         setUp(
-                seedLinks.injectOpen(atOnceUsers(1)),
-
-                redirectLoop.injectClosed(
-                        rampConcurrentUsers(0).to(5).during(Duration.ofSeconds(20)),
-                        constantConcurrentUsers(5).during(Duration.ofSeconds(50))
+                seedLinks.injectOpen(atOnceUsers(1)).andThen(
+                        redirectLoop.injectClosed(
+                                rampConcurrentUsers(0).to(5).during(Duration.ofSeconds(20)),
+                                constantConcurrentUsers(5).during(Duration.ofSeconds(50))
+                        )
                 )
         )
                 .protocols(protocol)

--- a/src/gatling/java/name/krot/smartlinks/load/SpikeSim.java
+++ b/src/gatling/java/name/krot/smartlinks/load/SpikeSim.java
@@ -23,20 +23,20 @@ public class SpikeSim extends SmartLinksSimulation {
 
     {
         setUp(
-                seedLinks.injectOpen(atOnceUsers(1)),
+                seedLinks.injectOpen(atOnceUsers(1)).andThen(
+                        redirectLoop.injectClosed(
+                                // baseline
+                                rampConcurrentUsers(0).to(10).during(Duration.ofSeconds(2)),
+                                constantConcurrentUsers(10).during(Duration.ofSeconds(60)),
 
-                redirectLoop.injectClosed(
-                        // baseline
-                        rampConcurrentUsers(0).to(10).during(Duration.ofSeconds(2)),
-                        constantConcurrentUsers(10).during(Duration.ofSeconds(60)),
+                                // spike — near-instantaneous ramp (10×)
+                                rampConcurrentUsers(10).to(100).during(Duration.ofSeconds(2)),
+                                constantConcurrentUsers(100).during(Duration.ofSeconds(120)),
 
-                        // spike — near-instantaneous ramp (10×)
-                        rampConcurrentUsers(10).to(100).during(Duration.ofSeconds(2)),
-                        constantConcurrentUsers(100).during(Duration.ofSeconds(120)),
-
-                        // recovery
-                        rampConcurrentUsers(100).to(10).during(Duration.ofSeconds(2)),
-                        constantConcurrentUsers(10).during(Duration.ofSeconds(90))
+                                // recovery
+                                rampConcurrentUsers(100).to(10).during(Duration.ofSeconds(2)),
+                                constantConcurrentUsers(10).during(Duration.ofSeconds(90))
+                        )
                 )
         )
                 .protocols(protocol)

--- a/src/gatling/java/name/krot/smartlinks/load/StressSim.java
+++ b/src/gatling/java/name/krot/smartlinks/load/StressSim.java
@@ -26,29 +26,29 @@ public class StressSim extends SmartLinksSimulation {
 
     {
         setUp(
-                seedLinks.injectOpen(atOnceUsers(1)),
+                seedLinks.injectOpen(atOnceUsers(1)).andThen(
+                        redirectLoop.injectClosed(
+                                rampConcurrentUsers(0).to(10).during(Duration.ofSeconds(5)),
+                                constantConcurrentUsers(10).during(STEP),
 
-                redirectLoop.injectClosed(
-                        rampConcurrentUsers(0).to(10).during(Duration.ofSeconds(5)),
-                        constantConcurrentUsers(10).during(STEP),
+                                rampConcurrentUsers(10).to(25).during(Duration.ofSeconds(5)),
+                                constantConcurrentUsers(25).during(STEP),
 
-                        rampConcurrentUsers(10).to(25).during(Duration.ofSeconds(5)),
-                        constantConcurrentUsers(25).during(STEP),
+                                rampConcurrentUsers(25).to(50).during(Duration.ofSeconds(5)),
+                                constantConcurrentUsers(50).during(STEP),
 
-                        rampConcurrentUsers(25).to(50).during(Duration.ofSeconds(5)),
-                        constantConcurrentUsers(50).during(STEP),
+                                rampConcurrentUsers(50).to(75).during(Duration.ofSeconds(5)),
+                                constantConcurrentUsers(75).during(STEP),
 
-                        rampConcurrentUsers(50).to(75).during(Duration.ofSeconds(5)),
-                        constantConcurrentUsers(75).during(STEP),
+                                rampConcurrentUsers(75).to(100).during(Duration.ofSeconds(5)),
+                                constantConcurrentUsers(100).during(STEP),
 
-                        rampConcurrentUsers(75).to(100).during(Duration.ofSeconds(5)),
-                        constantConcurrentUsers(100).during(STEP),
+                                rampConcurrentUsers(100).to(150).during(Duration.ofSeconds(5)),
+                                constantConcurrentUsers(150).during(STEP),
 
-                        rampConcurrentUsers(100).to(150).during(Duration.ofSeconds(5)),
-                        constantConcurrentUsers(150).during(STEP),
-
-                        rampConcurrentUsers(150).to(200).during(Duration.ofSeconds(5)),
-                        constantConcurrentUsers(200).during(STEP)
+                                rampConcurrentUsers(150).to(200).during(Duration.ofSeconds(5)),
+                                constantConcurrentUsers(200).during(STEP)
+                        )
                 )
         )
                 .protocols(protocol)

--- a/src/main/java/name/krot/smartlinks/controller/GlobalExceptionHandler.java
+++ b/src/main/java/name/krot/smartlinks/controller/GlobalExceptionHandler.java
@@ -2,12 +2,18 @@ package name.krot.smartlinks.controller;
 
 import name.krot.smartlinks.exception.NoMatchingRuleException;
 import name.krot.smartlinks.exception.ResourceNotFoundException;
+import name.krot.smartlinks.exception.SmartLinkAlreadyExistsException;
 import name.krot.smartlinks.exception.SmartLinkNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -25,11 +31,19 @@ public class GlobalExceptionHandler {
         log.error("Error MethodArgumentNotValidException ", ex);
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors().forEach((error) -> {
-            String fieldName = ((FieldError) error).getField();
+            String fieldName = error instanceof FieldError fieldError
+                    ? fieldError.getField()
+                    : objectErrorKey(error);
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);
         });
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
+    private static String objectErrorKey(ObjectError error) {
+        return error.getObjectName() == null || error.getObjectName().isBlank()
+                ? "request"
+                : error.getObjectName();
     }
 
     @ExceptionHandler(UnsupportedOperationException.class)
@@ -50,10 +64,30 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        log.warn("Request body could not be parsed: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Malformed request body");
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    public ResponseEntity<String> handleDataAccessException(DataAccessException ex) {
+        log.error("Backing store is unavailable", ex);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .header(HttpHeaders.RETRY_AFTER, "1")
+                .body("Storage temporarily unavailable");
+    }
+
     @ExceptionHandler(SmartLinkNotFoundException.class)
     public ResponseEntity<String> handleSmartLinkNotFoundException(SmartLinkNotFoundException ex) {
         log.error("Error SmartLinkNotFoundException ", ex);
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+
+    @ExceptionHandler(SmartLinkAlreadyExistsException.class)
+    public ResponseEntity<String> handleSmartLinkAlreadyExistsException(SmartLinkAlreadyExistsException ex) {
+        log.warn("Smart Link create conflict: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
     }
 
     @ExceptionHandler(NoMatchingRuleException.class)
@@ -64,6 +98,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleAllExceptions(Exception ex) {
+        if (ex instanceof ErrorResponse errorResponse) {
+            log.warn("Framework rejected request with status {}: {}",
+                    errorResponse.getStatusCode(), ex.getMessage());
+            return ResponseEntity.status(errorResponse.getStatusCode())
+                    .headers(errorResponse.getHeaders())
+                    .body(errorResponse.getStatusCode().toString());
+        }
         log.error("An unexpected error occurred", ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal Server Error");
     }

--- a/src/main/java/name/krot/smartlinks/controller/HttpRequestContextFactory.java
+++ b/src/main/java/name/krot/smartlinks/controller/HttpRequestContextFactory.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 @Component
 public class HttpRequestContextFactory implements RequestContextFactory {
@@ -20,8 +22,15 @@ public class HttpRequestContextFactory implements RequestContextFactory {
     public RequestContext from(HttpServletRequest request) {
         return new RequestContext(
                 LocalDateTime.ofInstant(clock.instant(), clock.getZone()),
-                request.getHeader("Accept-Language"),
+                combinedHeader(request, "Accept-Language"),
                 request.getHeader("User-Agent")
         );
+    }
+
+    private static String combinedHeader(HttpServletRequest request, String name) {
+        String value = Collections.list(request.getHeaders(name)).stream()
+                .filter(header -> header != null && !header.isBlank())
+                .collect(Collectors.joining(","));
+        return value.isEmpty() ? null : value;
     }
 }

--- a/src/main/java/name/krot/smartlinks/controller/RedirectController.java
+++ b/src/main/java/name/krot/smartlinks/controller/RedirectController.java
@@ -44,6 +44,9 @@ public class RedirectController implements RedirectControllerApi {
 
     @Override
     public ResponseEntity<Void> redirect(@Valid @PathVariable String smartLinkId, HttpServletRequest request) {
+        if (!SmartLink.isValidId(smartLinkId)) {
+            throw new IllegalArgumentException("Smart Link id contains unsupported characters or is too long");
+        }
         log.info("Received GET request, smartLinkId: {}, HttpServletRequest: {}", smartLinkId, request);
         URI redirectUri = redirectResolver.resolveRedirect(smartLinkId, requestContextFactory.from(request));
         return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();

--- a/src/main/java/name/krot/smartlinks/exception/SmartLinkAlreadyExistsException.java
+++ b/src/main/java/name/krot/smartlinks/exception/SmartLinkAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package name.krot.smartlinks.exception;
+
+public class SmartLinkAlreadyExistsException extends RuntimeException {
+
+    public SmartLinkAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/name/krot/smartlinks/model/Rule.java
+++ b/src/main/java/name/krot/smartlinks/model/Rule.java
@@ -20,15 +20,20 @@ import static java.util.function.Predicate.not;
 public class Rule implements Serializable {
     @Serial
     private static final long serialVersionUID = -4862926644813433701L;
+    public static final int MAX_PREDICATES = 16;
+    public static final int MAX_ARGUMENTS = 16;
+    public static final int MAX_REDIRECT_LENGTH = 2048;
 
     @NotNull(message = "Predicates list cannot be null")
+    @Size(max = MAX_PREDICATES, message = "Predicates list cannot exceed 16 entries")
     private List<@NotBlank(message = "Predicate name cannot be blank") String> predicates = new ArrayList<>();
 
     @NotNull(message = "Args cannot be null")
+    @Size(max = MAX_ARGUMENTS, message = "Args cannot exceed 16 entries")
     private Map<String, Object> args = new HashMap<>();
 
     @NotNull(message = "Redirect URL cannot be null")
-    @Size(max = 2048, message = "Redirect URL cannot exceed 2048 characters")
+    @Size(max = MAX_REDIRECT_LENGTH, message = "Redirect URL cannot exceed 2048 characters")
     private String redirectTo;
 
     @JsonIgnore
@@ -39,6 +44,7 @@ public class Rule implements Serializable {
 
     public static boolean isValidRedirectUrl(String value) {
         return Optional.ofNullable(value)
+                .filter(current -> current.length() <= MAX_REDIRECT_LENGTH)
                 .map(String::trim)
                 .filter(not(String::isBlank))
                 .flatMap(Rule::parseUri)

--- a/src/main/java/name/krot/smartlinks/model/SmartLink.java
+++ b/src/main/java/name/krot/smartlinks/model/SmartLink.java
@@ -16,13 +16,19 @@ import java.util.List;
 public class SmartLink implements Serializable {
     @Serial
     private static final long serialVersionUID = -4862926644813433702L;
+    public static final int MAX_RULES = 64;
+    private static final int MAX_ID_LENGTH = 128;
+    private static final java.util.regex.Pattern VALID_ID =
+            java.util.regex.Pattern.compile("^(?!\\.{1,2}$)[A-Za-z0-9._-]+$");
 
     @NotBlank(message = "Smart Link id cannot be blank")
     @Size(max = 128, message = "Smart Link id cannot exceed 128 characters")
-    @Pattern(regexp = "^[A-Za-z0-9._-]+$", message = "Smart Link id contains unsupported characters")
+    @Pattern(regexp = "^(?!\\.{1,2}$)[A-Za-z0-9._-]+$",
+            message = "Smart Link id contains unsupported characters")
     private String id;
     @Valid
     @NotEmpty(message = "Rules list cannot be empty")
+    @Size(max = MAX_RULES, message = "Rules list cannot exceed 64 entries")
     private List<Rule> rules = new ArrayList<>();
 
     public String getId() {
@@ -39,5 +45,10 @@ public class SmartLink implements Serializable {
 
     public void setRules(List<Rule> rules) {
         this.rules = rules;
+    }
+
+    public static boolean isValidId(String value) {
+        return value != null && !value.isBlank() && value.length() <= MAX_ID_LENGTH
+                && VALID_ID.matcher(value).matches();
     }
 }

--- a/src/main/java/name/krot/smartlinks/predicate/DateRangePredicate.java
+++ b/src/main/java/name/krot/smartlinks/predicate/DateRangePredicate.java
@@ -3,6 +3,7 @@ package name.krot.smartlinks.predicate;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
 @Component
 public class DateRangePredicate implements Predicate {
@@ -14,8 +15,33 @@ public class DateRangePredicate implements Predicate {
 
     @Override
     public boolean evaluate(RequestContext context, PredicateArguments arguments) {
-        LocalDateTime start = LocalDateTime.parse(arguments.getString("startWith"));
-        LocalDateTime end = LocalDateTime.parse(arguments.getString("endWith"));
+        DateRange range = range(arguments);
+        LocalDateTime start = range.start();
+        LocalDateTime end = range.end();
         return !context.requestTime().isBefore(start) && !context.requestTime().isAfter(end);
+    }
+
+    @Override
+    public void validateArguments(PredicateArguments arguments) {
+        range(arguments);
+    }
+
+    private static DateRange range(PredicateArguments arguments) {
+        LocalDateTime start;
+        LocalDateTime end;
+        try {
+            start = LocalDateTime.parse(arguments.getString("startWith"));
+            end = LocalDateTime.parse(arguments.getString("endWith"));
+        } catch (DateTimeParseException exception) {
+            throw new IllegalArgumentException(
+                    "DateRange startWith and endWith must be ISO-8601 local date-times", exception);
+        }
+        if (end.isBefore(start)) {
+            throw new IllegalArgumentException("DateRange endWith must not be before startWith");
+        }
+        return new DateRange(start, end);
+    }
+
+    private record DateRange(LocalDateTime start, LocalDateTime end) {
     }
 }

--- a/src/main/java/name/krot/smartlinks/predicate/DeviceTypePredicate.java
+++ b/src/main/java/name/krot/smartlinks/predicate/DeviceTypePredicate.java
@@ -3,9 +3,12 @@ package name.krot.smartlinks.predicate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Set;
 
 @Component
 public class DeviceTypePredicate implements Predicate {
+
+    private static final Set<String> SUPPORTED_DEVICES = Set.of("mobile", "desktop", "unknown");
 
     private final DeviceTypeResolver deviceTypeResolver;
 
@@ -22,6 +25,19 @@ public class DeviceTypePredicate implements Predicate {
     public boolean evaluate(RequestContext context, PredicateArguments arguments) {
         List<String> devices = arguments.getStringList("devices");
         String deviceType = deviceTypeResolver.resolve(context.userAgent());
-        return devices.contains(deviceType);
+        return devices.stream().anyMatch(device -> device.equalsIgnoreCase(deviceType));
+    }
+
+    @Override
+    public void validateArguments(PredicateArguments arguments) {
+        List<String> devices = arguments.getStringList("devices");
+        if (devices.isEmpty()) {
+            throw new IllegalArgumentException("DeviceType predicate requires at least one device type");
+        }
+        for (String device : devices) {
+            if (device == null || !SUPPORTED_DEVICES.contains(device.toLowerCase(java.util.Locale.ROOT))) {
+                throw new IllegalArgumentException("Unsupported device type: " + device);
+            }
+        }
     }
 }

--- a/src/main/java/name/krot/smartlinks/predicate/LanguagePredicate.java
+++ b/src/main/java/name/krot/smartlinks/predicate/LanguagePredicate.java
@@ -3,6 +3,8 @@ package name.krot.smartlinks.predicate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.IllformedLocaleException;
 
 @Component
 public class LanguagePredicate implements Predicate {
@@ -15,6 +17,40 @@ public class LanguagePredicate implements Predicate {
     @Override
     public boolean evaluate(RequestContext context, PredicateArguments arguments) {
         List<String> languages = arguments.getStringList("language");
-        return languages.contains(context.acceptLanguage());
+        String acceptLanguage = context.acceptLanguage();
+        if (acceptLanguage == null || acceptLanguage.isBlank() || languages.isEmpty()) {
+            return false;
+        }
+        try {
+            List<Locale.LanguageRange> requested = Locale.LanguageRange.parse(acceptLanguage);
+            return !Locale.filterTags(requested, languages).isEmpty();
+        } catch (IllegalArgumentException ignored) {
+            return false;
+        }
+    }
+
+    @Override
+    public void validateArguments(PredicateArguments arguments) {
+        List<String> languages = arguments.getStringList("language");
+        if (languages.isEmpty()) {
+            throw new IllegalArgumentException("Language predicate requires at least one language tag");
+        }
+        for (String language : languages) {
+            if (!isWellFormedLanguageTag(language)) {
+                throw new IllegalArgumentException("Invalid language tag: " + language);
+            }
+        }
+    }
+
+    private static boolean isWellFormedLanguageTag(String language) {
+        if (language == null || language.isBlank() || !language.equals(language.trim())) {
+            return false;
+        }
+        try {
+            new Locale.Builder().setLanguageTag(language).build();
+            return true;
+        } catch (IllformedLocaleException exception) {
+            return false;
+        }
     }
 }

--- a/src/main/java/name/krot/smartlinks/predicate/Predicate.java
+++ b/src/main/java/name/krot/smartlinks/predicate/Predicate.java
@@ -4,4 +4,8 @@ public interface Predicate {
     String name();
 
     boolean evaluate(RequestContext context, PredicateArguments arguments);
+
+    default void validateArguments(PredicateArguments arguments) {
+        // Predicates without configurable arguments can keep the default implementation.
+    }
 }

--- a/src/main/java/name/krot/smartlinks/predicate/PredicateArguments.java
+++ b/src/main/java/name/krot/smartlinks/predicate/PredicateArguments.java
@@ -1,5 +1,7 @@
 package name.krot.smartlinks.predicate;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -9,7 +11,9 @@ public final class PredicateArguments {
     private final Map<String, Object> values;
 
     public PredicateArguments(Map<String, Object> values) {
-        this.values = values == null ? Map.of() : Map.copyOf(values);
+        this.values = values == null
+                ? Map.of()
+                : Collections.unmodifiableMap(new HashMap<>(values));
     }
 
     public String getString(String key) {

--- a/src/main/java/name/krot/smartlinks/predicate/UserAgentDeviceTypeResolver.java
+++ b/src/main/java/name/krot/smartlinks/predicate/UserAgentDeviceTypeResolver.java
@@ -3,6 +3,7 @@ package name.krot.smartlinks.predicate;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -20,7 +21,8 @@ public class UserAgentDeviceTypeResolver implements DeviceTypeResolver {
 
     @Override
     public String resolve(String userAgent) {
-        Optional<String> currentUserAgent = Optional.ofNullable(userAgent);
+        Optional<String> currentUserAgent = Optional.ofNullable(userAgent)
+                .filter(current -> !current.isBlank());
         return RULES.stream()
                 .map(rule -> rule.resolve(currentUserAgent))
                 .flatMap(Optional::stream)
@@ -29,7 +31,8 @@ public class UserAgentDeviceTypeResolver implements DeviceTypeResolver {
     }
 
     private static boolean isMobile(String userAgent) {
-        return Stream.of("Mobile", "iPhone", "Android").anyMatch(userAgent::contains);
+        String normalized = userAgent.toLowerCase(Locale.ROOT);
+        return Stream.of("mobile", "iphone", "ipad", "android").anyMatch(normalized::contains);
     }
 
     private record DeviceTypeRule(Function<Optional<String>, Optional<String>> resolver) {

--- a/src/main/java/name/krot/smartlinks/repository/RedisSmartLinkRepository.java
+++ b/src/main/java/name/krot/smartlinks/repository/RedisSmartLinkRepository.java
@@ -6,6 +6,7 @@ import name.krot.smartlinks.model.SmartLink;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.time.Duration;
@@ -18,7 +19,7 @@ public class RedisSmartLinkRepository implements SmartLinkRepository {
 
     private final StringRedisTemplate stringTemplate;
     private final JsonMapper jsonMapper;
-    private final Cache<String, SmartLink> localCache;
+    private final Cache<String, String> localCache;
 
     public RedisSmartLinkRepository(StringRedisTemplate stringTemplate, JsonMapper jsonMapper) {
         this.stringTemplate = stringTemplate;
@@ -30,32 +31,48 @@ public class RedisSmartLinkRepository implements SmartLinkRepository {
     }
 
     @Override
-    public void save(SmartLink smartLink) {
+    public boolean saveIfAbsent(SmartLink smartLink) {
         try {
-            stringTemplate.opsForValue().set(KEY_PREFIX + smartLink.getId(),
-                    jsonMapper.writeValueAsString(smartLink));
-            localCache.put(smartLink.getId(), smartLink);
+            String json = jsonMapper.writeValueAsString(smartLink);
+            boolean inserted = Boolean.TRUE.equals(stringTemplate.opsForValue()
+                    .setIfAbsent(KEY_PREFIX + smartLink.getId(), json));
+            if (inserted) {
+                localCache.put(smartLink.getId(), json);
+            }
+            return inserted;
         } catch (JacksonException e) {
-            throw new IllegalArgumentException("Cannot serialize SmartLink: " + smartLink.getId(), e);
+            throw new IllegalStateException("Cannot serialize SmartLink: " + smartLink.getId(), e);
         }
     }
 
     @Override
     public Optional<SmartLink> findById(String id) {
-        SmartLink cached = localCache.getIfPresent(id);
+        String cached = localCache.getIfPresent(id);
         if (cached != null) {
-            return Optional.of(cached);
+            return Optional.of(deserialize(id, cached));
         }
         String json = stringTemplate.opsForValue().get(KEY_PREFIX + id);
         if (json == null) {
             return Optional.empty();
         }
+        SmartLink smartLink = deserialize(id, json);
+        localCache.put(id, json);
+        return Optional.of(smartLink);
+    }
+
+    private SmartLink deserialize(String id, String json) {
         try {
-            SmartLink smartLink = jsonMapper.readValue(json, SmartLink.class);
-            localCache.put(id, smartLink);
-            return Optional.of(smartLink);
+            // Redis is a durable cross-version boundary. Ignore fields written by a newer
+            // application version so rolling deployments do not break older replicas.
+            SmartLink smartLink = jsonMapper.readerFor(SmartLink.class)
+                    .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                    .readValue(json);
+            if (!id.equals(smartLink.getId())) {
+                throw new IllegalStateException("Stored SmartLink id does not match Redis key: " + id);
+            }
+            return smartLink;
         } catch (JacksonException e) {
-            throw new IllegalArgumentException("Cannot deserialize SmartLink for key: " + id, e);
+            throw new IllegalStateException("Cannot deserialize SmartLink for key: " + id, e);
         }
     }
 }

--- a/src/main/java/name/krot/smartlinks/repository/SmartLinkRepository.java
+++ b/src/main/java/name/krot/smartlinks/repository/SmartLinkRepository.java
@@ -5,7 +5,7 @@ import name.krot.smartlinks.model.SmartLink;
 import java.util.Optional;
 
 public interface SmartLinkRepository {
-    void save(SmartLink smartLink);
+    boolean saveIfAbsent(SmartLink smartLink);
 
     Optional<SmartLink> findById(String id);
 }

--- a/src/main/java/name/krot/smartlinks/service/DefaultSmartLinkService.java
+++ b/src/main/java/name/krot/smartlinks/service/DefaultSmartLinkService.java
@@ -1,6 +1,7 @@
 package name.krot.smartlinks.service;
 
 import name.krot.smartlinks.model.SmartLink;
+import name.krot.smartlinks.exception.SmartLinkAlreadyExistsException;
 import name.krot.smartlinks.repository.SmartLinkRepository;
 import org.springframework.stereotype.Service;
 
@@ -10,14 +11,20 @@ import java.util.Optional;
 public class DefaultSmartLinkService implements SmartLinkService {
 
     private final SmartLinkRepository smartLinkRepository;
+    private final SmartLinkDefinitionValidator definitionValidator;
 
-    public DefaultSmartLinkService(SmartLinkRepository smartLinkRepository) {
+    public DefaultSmartLinkService(SmartLinkRepository smartLinkRepository,
+                                   SmartLinkDefinitionValidator definitionValidator) {
         this.smartLinkRepository = smartLinkRepository;
+        this.definitionValidator = definitionValidator;
     }
 
     @Override
     public void saveSmartLink(SmartLink smartLink) {
-        smartLinkRepository.save(smartLink);
+        definitionValidator.validate(smartLink);
+        if (!smartLinkRepository.saveIfAbsent(smartLink)) {
+            throw new SmartLinkAlreadyExistsException("Smart Link already exists: " + smartLink.getId());
+        }
     }
 
     @Override

--- a/src/main/java/name/krot/smartlinks/service/SmartLinkDefinitionValidator.java
+++ b/src/main/java/name/krot/smartlinks/service/SmartLinkDefinitionValidator.java
@@ -1,0 +1,74 @@
+package name.krot.smartlinks.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import name.krot.smartlinks.model.Rule;
+import name.krot.smartlinks.model.SmartLink;
+import name.krot.smartlinks.predicate.Predicate;
+import name.krot.smartlinks.predicate.PredicateArguments;
+import name.krot.smartlinks.predicate.PredicateFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SmartLinkDefinitionValidator {
+
+    private final PredicateFactory predicateFactory;
+
+    public SmartLinkDefinitionValidator(PredicateFactory predicateFactory) {
+        this.predicateFactory = predicateFactory;
+    }
+
+    public void validate(SmartLink smartLink) {
+        if (smartLink == null) {
+            throw new IllegalArgumentException("Smart Link cannot be null");
+        }
+        if (!SmartLink.isValidId(smartLink.getId())) {
+            throw new IllegalArgumentException("Smart Link id contains unsupported characters or is too long");
+        }
+        List<Rule> rules = smartLink.getRules();
+        if (rules == null || rules.isEmpty()) {
+            throw new IllegalArgumentException("Rules list cannot be empty");
+        }
+        if (rules.size() > SmartLink.MAX_RULES) {
+            throw new IllegalArgumentException("Rules list cannot exceed " + SmartLink.MAX_RULES + " entries");
+        }
+        for (int index = 0; index < rules.size(); index++) {
+            validateRule(rules.get(index), index);
+            if (rules.get(index).getPredicates().isEmpty() && index != rules.size() - 1) {
+                throw new IllegalArgumentException("Fallback rule must be the final rule");
+            }
+        }
+    }
+
+    private void validateRule(Rule rule, int index) {
+        if (rule == null) {
+            throw new IllegalArgumentException("Rule at index " + index + " cannot be null");
+        }
+        if (!Rule.isValidRedirectUrl(rule.getRedirectTo())) {
+            throw new IllegalArgumentException("Rule at index " + index + " has an invalid redirect URL");
+        }
+        if (rule.getPredicates() == null || rule.getArgs() == null) {
+            throw new IllegalArgumentException("Rule predicates and args cannot be null");
+        }
+        if (rule.getPredicates().size() > Rule.MAX_PREDICATES) {
+            throw new IllegalArgumentException(
+                    "Rule predicates cannot exceed " + Rule.MAX_PREDICATES + " entries");
+        }
+        if (rule.getArgs().size() > Rule.MAX_ARGUMENTS) {
+            throw new IllegalArgumentException("Rule args cannot exceed " + Rule.MAX_ARGUMENTS + " entries");
+        }
+        PredicateArguments arguments = new PredicateArguments(rule.getArgs());
+        Set<String> names = new HashSet<>();
+        for (String name : rule.getPredicates()) {
+            if (name == null || name.isBlank()) {
+                throw new IllegalArgumentException("Predicate name cannot be blank");
+            }
+            if (!names.add(name)) {
+                throw new IllegalArgumentException("Duplicate predicate: " + name);
+            }
+            Predicate predicate = predicateFactory.createPredicate(name);
+            predicate.validateArguments(arguments);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,12 +8,28 @@ spring:
     redis:
       host: localhost
       port: 6379
+      connect-timeout: 2s
+      timeout: 2s
       lettuce:
         pool:
           enabled: true
           max-active: 16
           max-idle: 8
           min-idle: 2
+          max-wait: 2s
+  jackson:
+    deserialization:
+      fail-on-unknown-properties: true
+    read:
+      strict-duplicate-detection: true
+    factory:
+      constraints:
+        read:
+          max-nesting-depth: 32
+          max-document-length: 262144
+          max-token-count: 10000
+          max-string-length: 4096
+          max-name-length: 128
 springdoc:
   swagger-ui:
     config-url: /v3/api-docs/swagger-config
@@ -26,6 +42,15 @@ server:
     max-connections: 10000
     accept-count: 1000
 management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: readinessState,redis
+        liveness:
+          include: livenessState
   endpoints:
     web:
       exposure:

--- a/src/test/java/name/krot/smartlinks/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/name/krot/smartlinks/controller/GlobalExceptionHandlerTest.java
@@ -1,11 +1,14 @@
 package name.krot.smartlinks.controller;
 
-
 import name.krot.smartlinks.exception.NoMatchingRuleException;
 import name.krot.smartlinks.exception.ResourceNotFoundException;
 import name.krot.smartlinks.exception.SmartLinkNotFoundException;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -65,6 +68,26 @@ class GlobalExceptionHandlerTest {
 
         assertEquals(500, response.getStatusCode().value());
         assertEquals("Internal Server Error", response.getBody());
+    }
+
+    @Test
+    void malformedRequestBodyIsAClientError() {
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException(
+                "broken json", new MockHttpInputMessage(new byte[0]));
+        ResponseEntity<String> response = exceptionHandler.handleHttpMessageNotReadableException(ex);
+
+        assertEquals(400, response.getStatusCode().value());
+        assertEquals("Malformed request body", response.getBody());
+    }
+
+    @Test
+    void storageFailureIsReportedAsRetryableServiceOutage() {
+        ResponseEntity<String> response = exceptionHandler.handleDataAccessException(
+                new DataAccessResourceFailureException("redis unavailable"));
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals("1", response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER));
+        assertEquals("Storage temporarily unavailable", response.getBody());
     }
 
 }

--- a/src/test/java/name/krot/smartlinks/controller/HttpRequestContextFactoryTest.java
+++ b/src/test/java/name/krot/smartlinks/controller/HttpRequestContextFactoryTest.java
@@ -27,4 +27,17 @@ class HttpRequestContextFactoryTest {
         assertEquals("ru-RU", context.acceptLanguage());
         assertEquals("Mozilla/5.0", context.userAgent());
     }
+
+    @Test
+    void combinesRepeatedAcceptLanguageHeaders() {
+        Clock clock = Clock.fixed(Instant.parse("2024-11-15T12:00:00Z"), ZoneId.of("UTC"));
+        HttpRequestContextFactory factory = new HttpRequestContextFactory(clock);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Accept-Language", "en-US;q=0.5");
+        request.addHeader("Accept-Language", "ru-RU;q=0.9");
+
+        RequestContext context = factory.from(request);
+
+        assertEquals("en-US;q=0.5,ru-RU;q=0.9", context.acceptLanguage());
+    }
 }

--- a/src/test/java/name/krot/smartlinks/controller/RedirectControllerTest.java
+++ b/src/test/java/name/krot/smartlinks/controller/RedirectControllerTest.java
@@ -2,12 +2,14 @@ package name.krot.smartlinks.controller;
 
 import name.krot.smartlinks.exception.NoMatchingRuleException;
 import name.krot.smartlinks.exception.SmartLinkNotFoundException;
+import name.krot.smartlinks.exception.SmartLinkAlreadyExistsException;
 import name.krot.smartlinks.model.SmartLink;
 import name.krot.smartlinks.predicate.RequestContext;
 import name.krot.smartlinks.service.RedirectResolver;
 import name.krot.smartlinks.service.SmartLinkService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -25,10 +27,13 @@ import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -86,6 +91,43 @@ class RedirectControllerTest {
     }
 
     @Test
+    void redisOutageIsReportedAsRetryableServiceUnavailable() throws Exception {
+        RequestContext context = requestContext(null);
+        when(requestContextFactory.from(any())).thenReturn(context);
+        when(redirectResolver.resolveRedirect(SMART_LINK_ID, context))
+                .thenThrow(new DataAccessResourceFailureException("redis unavailable"));
+
+        mockMvc.perform(get("/s/{smartLinkId}", SMART_LINK_ID))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(header().string("Retry-After", "1"));
+    }
+
+    @Test
+    void redirectRejectsInvalidOrOversizedIdsBeforeRepositoryLookup() throws Exception {
+        mockMvc.perform(get("/s/{smartLinkId}", "bad$id"))
+                .andExpect(status().isBadRequest());
+        mockMvc.perform(get("/s/{smartLinkId}", "a".repeat(129)))
+                .andExpect(status().isBadRequest());
+
+        verify(redirectResolver, never()).resolveRedirect(any(), any());
+    }
+
+    @Test
+    void unknownRouteKeepsFrameworkNotFoundStatus() throws Exception {
+        mockMvc.perform(get("/does-not-exist"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void methodNotAllowedKeepsFrameworkAllowHeader() throws Exception {
+        mockMvc.perform(put("/api/smartlinks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validSmartLinkJson()))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(header().string("Allow", "POST"));
+    }
+
+    @Test
     void testCreateSmartLink() throws Exception {
         mockMvc.perform(post("/api/smartlinks")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -110,10 +152,49 @@ class RedirectControllerTest {
     }
 
     @Test
+    void testCreateSmartLinkRejectsDuplicateIdWithoutOverwrite() throws Exception {
+        doThrow(new SmartLinkAlreadyExistsException("Smart Link already exists: " + SMART_LINK_ID))
+                .when(smartLinkService).saveSmartLink(any());
+
+        mockMvc.perform(post("/api/smartlinks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validSmartLinkJson()))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
     void testCreateSmartLinkRejectsRedirectWithoutHost() throws Exception {
         mockMvc.perform(post("/api/smartlinks")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidRedirectSmartLinkJson()))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createRejectsDuplicateJsonProperties() throws Exception {
+        String duplicateId = fallbackSmartLinkJson().replace(
+                "\"id\": \"smartlink123\"",
+                "\"id\": \"smartlink123\", \"id\": \"ambiguous\"");
+
+        mockMvc.perform(post("/api/smartlinks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(duplicateId))
+                .andExpect(status().isBadRequest());
+
+        verify(smartLinkService, never()).saveSmartLink(any());
+    }
+
+    @Test
+    void createRejectsUnknownJsonProperties() throws Exception {
+        String unknownProperty = fallbackSmartLinkJson().replace(
+                "\"id\": \"smartlink123\"",
+                "\"id\": \"smartlink123\", \"idd\": \"typo\"");
+
+        mockMvc.perform(post("/api/smartlinks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(unknownProperty))
+                .andExpect(status().isBadRequest());
+
+        verify(smartLinkService, never()).saveSmartLink(any());
     }
 }

--- a/src/test/java/name/krot/smartlinks/model/RuleTest.java
+++ b/src/test/java/name/krot/smartlinks/model/RuleTest.java
@@ -33,5 +33,7 @@ class RuleTest {
         assertFalse(Rule.isValidRedirectUrl("https:otus.ru/no-host"));
         assertFalse(Rule.isValidRedirectUrl("https://"));
         assertFalse(Rule.isValidRedirectUrl("https://trusted.example@evil.example/path"));
+        assertFalse(Rule.isValidRedirectUrl("https://example.com/" + "a".repeat(2049)));
+        assertFalse(Rule.isValidRedirectUrl(" " + "https://example.com/" + "a".repeat(2028) + " "));
     }
 }

--- a/src/test/java/name/krot/smartlinks/model/SmartLinkTest.java
+++ b/src/test/java/name/krot/smartlinks/model/SmartLinkTest.java
@@ -8,6 +8,7 @@ import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.fallbackRule;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class SmartLinkTest {
 
@@ -18,5 +19,11 @@ class SmartLinkTest {
         assertEquals(SMART_LINK_ID, smartLink.getId());
         assertEquals(1, smartLink.getRules().size());
         assertEquals(RU_REDIRECT_URL, smartLink.getRules().get(0).getRedirectTo());
+    }
+
+    @Test
+    void dotSegmentsAreNotValidPublicIds() {
+        assertFalse(SmartLink.isValidId("."));
+        assertFalse(SmartLink.isValidId(".."));
     }
 }

--- a/src/test/java/name/krot/smartlinks/predicate/DateRangePredicateTest.java
+++ b/src/test/java/name/krot/smartlinks/predicate/DateRangePredicateTest.java
@@ -3,7 +3,6 @@ package name.krot.smartlinks.predicate;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeParseException;
 
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.dateRangeArguments;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContextAt;
@@ -52,7 +51,7 @@ class DateRangePredicateTest {
     void testDateRangePredicateWithInvalidArgs() {
         RequestContext context = requestContextAt(LocalDateTime.now());
 
-        assertThrows(DateTimeParseException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             dateRangePredicate.evaluate(context, dateRangeArguments("invalid date", "invalid date"));
         });
     }

--- a/src/test/java/name/krot/smartlinks/predicate/DeviceTypePredicateTest.java
+++ b/src/test/java/name/krot/smartlinks/predicate/DeviceTypePredicateTest.java
@@ -56,4 +56,24 @@ class DeviceTypePredicateTest {
         boolean result = deviceTypePredicate.evaluate(context, deviceArguments(List.of("Mobile")));
         assertFalse(result);
     }
+
+    @Test
+    void blankUserAgentIsUnknownInsteadOfDesktop() {
+        assertTrue(deviceTypePredicate.evaluate(
+                requestContext(null, "   "),
+                deviceArguments(List.of("Unknown"))));
+        assertFalse(deviceTypePredicate.evaluate(
+                requestContext(null, ""),
+                deviceArguments(List.of("Desktop"))));
+    }
+
+    @Test
+    void mobileDetectionIsCaseInsensitiveAndRecognizesTablets() {
+        assertTrue(deviceTypePredicate.evaluate(
+                requestContext(null, "mozilla/5.0 (linux; android 14; mobile)"),
+                deviceArguments(List.of("Mobile"))));
+        assertTrue(deviceTypePredicate.evaluate(
+                requestContext(null, "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)"),
+                deviceArguments(List.of("Mobile"))));
+    }
 }

--- a/src/test/java/name/krot/smartlinks/predicate/LanguagePredicateTest.java
+++ b/src/test/java/name/krot/smartlinks/predicate/LanguagePredicateTest.java
@@ -4,10 +4,12 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.languageArguments;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -40,5 +42,31 @@ class LanguagePredicateTest {
                 languageArguments(Collections.emptyList())
         );
         assertFalse(result);
+    }
+
+    @Test
+    void parsesWeightedAcceptLanguageHeader() {
+        boolean result = languagePredicate.evaluate(
+                requestContext("en-US;q=0.5, ru-RU;q=0.9, ru;q=0.8"),
+                languageArguments(Arrays.asList("ru", "ru-RU"))
+        );
+
+        assertTrue(result);
+    }
+
+    @Test
+    void malformedOrMissingAcceptLanguageDoesNotBreakRedirectResolution() {
+        assertFalse(languagePredicate.evaluate(
+                requestContext("not a valid language header;="),
+                languageArguments(Arrays.asList("ru", "ru-RU"))));
+        assertFalse(languagePredicate.evaluate(
+                requestContext(null),
+                languageArguments(Arrays.asList("ru", "ru-RU"))));
+    }
+
+    @Test
+    void rejectsIllFormedConfiguredLanguageTag() {
+        assertThrows(IllegalArgumentException.class,
+                () -> languagePredicate.validateArguments(languageArguments(List.of("en-@"))));
     }
 }

--- a/src/test/java/name/krot/smartlinks/repository/RedisSmartLinkRepositoryTest.java
+++ b/src/test/java/name/krot/smartlinks/repository/RedisSmartLinkRepositoryTest.java
@@ -1,0 +1,96 @@
+package name.krot.smartlinks.repository;
+
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.fallbackRule;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import name.krot.smartlinks.model.SmartLink;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.DeserializationFeature;
+
+class RedisSmartLinkRepositoryTest {
+
+    @Test
+    void cachedValuesCannotBeMutatedWithoutSaving() {
+        StringRedisTemplate template = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> values = mock(ValueOperations.class);
+        when(template.opsForValue()).thenReturn(values);
+        when(values.setIfAbsent(anyString(), anyString())).thenReturn(true);
+        RedisSmartLinkRepository repository = new RedisSmartLinkRepository(
+                template, JsonMapper.builder().build());
+        SmartLink original = smartLink(fallbackRule("https://example.com/original"));
+
+        repository.saveIfAbsent(original);
+        original.getRules().getFirst().setRedirectTo("https://example.com/mutated-after-save");
+        SmartLink firstRead = repository.findById(SMART_LINK_ID).orElseThrow();
+        firstRead.getRules().getFirst().setRedirectTo("https://example.com/mutated-read");
+        SmartLink secondRead = repository.findById(SMART_LINK_ID).orElseThrow();
+
+        assertEquals("https://example.com/original", secondRead.getRules().getFirst().getRedirectTo());
+    }
+
+    @Test
+    void malformedRedisValueIsNotCachedAndIsReportedAsServerStateFailure() throws Exception {
+        StringRedisTemplate template = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> values = mock(ValueOperations.class);
+        JsonMapper mapper = JsonMapper.builder().build();
+        SmartLink expected = smartLink(fallbackRule("https://example.com/valid"));
+        when(template.opsForValue()).thenReturn(values);
+        when(values.get("sl:" + SMART_LINK_ID))
+                .thenReturn("{broken-json", mapper.writeValueAsString(expected));
+        RedisSmartLinkRepository repository = new RedisSmartLinkRepository(template, mapper);
+
+        assertThrows(IllegalStateException.class, () -> repository.findById(SMART_LINK_ID));
+        SmartLink recovered = repository.findById(SMART_LINK_ID).orElseThrow();
+
+        assertEquals("https://example.com/valid", recovered.getRules().getFirst().getRedirectTo());
+        verify(values, times(2)).get("sl:" + SMART_LINK_ID);
+    }
+
+    @Test
+    void ignoresUnknownStoredFieldsDuringRollingDeployments() throws Exception {
+        StringRedisTemplate template = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> values = mock(ValueOperations.class);
+        JsonMapper mapper = JsonMapper.builder()
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
+        String jsonFromNewerVersion = mapper.writeValueAsString(
+                        smartLink(fallbackRule("https://example.com/compatible")))
+                .replaceFirst("\\{", "{\"newerVersionMetadata\":true,");
+        when(template.opsForValue()).thenReturn(values);
+        when(values.get("sl:" + SMART_LINK_ID)).thenReturn(jsonFromNewerVersion);
+        RedisSmartLinkRepository repository = new RedisSmartLinkRepository(template, mapper);
+
+        SmartLink loaded = repository.findById(SMART_LINK_ID).orElseThrow();
+
+        assertEquals("https://example.com/compatible", loaded.getRules().getFirst().getRedirectTo());
+    }
+
+    @Test
+    void rejectsStoredPayloadWhoseIdDoesNotMatchRedisKey() throws Exception {
+        StringRedisTemplate template = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> values = mock(ValueOperations.class);
+        JsonMapper mapper = JsonMapper.builder().build();
+        SmartLink mismatched = smartLink(fallbackRule("https://example.com/wrong"));
+        mismatched.setId("different-id");
+        when(template.opsForValue()).thenReturn(values);
+        when(values.get("sl:" + SMART_LINK_ID)).thenReturn(mapper.writeValueAsString(mismatched));
+        RedisSmartLinkRepository repository = new RedisSmartLinkRepository(template, mapper);
+
+        assertThrows(IllegalStateException.class, () -> repository.findById(SMART_LINK_ID));
+    }
+}

--- a/src/test/java/name/krot/smartlinks/repository/SmartLinkRepositoryDockerTest.java
+++ b/src/test/java/name/krot/smartlinks/repository/SmartLinkRepositoryDockerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.data.redis.test.autoconfigure.DataRedisTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
@@ -16,11 +17,14 @@ import org.testcontainers.utility.DockerImageName;
 import tools.jackson.databind.json.JsonMapper;
 
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.fallbackRule;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 @DataRedisTest
 @Import({RedisSmartLinkRepository.class, SmartLinkRepositoryDockerTest.TestConfig.class})
 class SmartLinkRepositoryDockerTest {
@@ -44,6 +48,12 @@ class SmartLinkRepositoryDockerTest {
     @Autowired
     private SmartLinkRepository smartLinkRepository;
 
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private JsonMapper jsonMapper;
+
     @DynamicPropertySource
     static void redisProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.data.redis.host", redisContainer::getHost);
@@ -51,14 +61,18 @@ class SmartLinkRepositoryDockerTest {
     }
 
     @Test
-    void savesAndLoadsSmartLinkById() {
-        SmartLink smartLink = smartLink();
+    void createsSmartLinkOnceWithoutOverwritingRedis() {
+        SmartLink smartLink = smartLink(fallbackRule("https://example.com/original"));
+        SmartLink replacement = smartLink(fallbackRule("https://example.com/replacement"));
 
-        smartLinkRepository.save(smartLink);
+        assertTrue(smartLinkRepository.saveIfAbsent(smartLink));
+        assertFalse(smartLinkRepository.saveIfAbsent(replacement));
 
-        SmartLink result = smartLinkRepository.findById(SMART_LINK_ID).orElseThrow();
+        SmartLinkRepository uncachedRepository = new RedisSmartLinkRepository(stringRedisTemplate, jsonMapper);
+        SmartLink result = uncachedRepository.findById(SMART_LINK_ID).orElseThrow();
 
         assertNotNull(result);
         assertEquals(SMART_LINK_ID, result.getId());
+        assertEquals("https://example.com/original", result.getRules().getFirst().getRedirectTo());
     }
 }

--- a/src/test/java/name/krot/smartlinks/service/SmartLinkDefinitionValidatorTest.java
+++ b/src/test/java/name/krot/smartlinks/service/SmartLinkDefinitionValidatorTest.java
@@ -1,0 +1,73 @@
+package name.krot.smartlinks.service;
+
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.fallbackRule;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.rule;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+import name.krot.smartlinks.model.SmartLink;
+import name.krot.smartlinks.predicate.DateRangePredicate;
+import name.krot.smartlinks.predicate.DeviceTypePredicate;
+import name.krot.smartlinks.predicate.LanguagePredicate;
+import name.krot.smartlinks.predicate.PredicateFactoryImpl;
+import name.krot.smartlinks.predicate.UserAgentDeviceTypeResolver;
+import org.junit.jupiter.api.Test;
+
+class SmartLinkDefinitionValidatorTest {
+
+    private final SmartLinkDefinitionValidator validator = new SmartLinkDefinitionValidator(
+            new PredicateFactoryImpl(List.of(
+                    new DateRangePredicate(),
+                    new LanguagePredicate(),
+                    new DeviceTypePredicate(new UserAgentDeviceTypeResolver()))));
+
+    @Test
+    void acceptsValidAndFallbackRules() {
+        assertDoesNotThrow(() -> validator.validate(smartLink(
+                rule(List.of("Language"), "https://example.com", Map.of("language", List.of("ru-RU"))),
+                fallbackRule("https://example.com/fallback"))));
+    }
+
+    @Test
+    void rejectsUnknownDuplicateAndInvalidPredicateArguments() {
+        assertThrows(IllegalArgumentException.class, () -> validator.validate(smartLink(
+                rule(List.of("Unknown"), "https://example.com", Map.of()))));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate(smartLink(
+                rule(List.of("Language", "Language"), "https://example.com",
+                        Map.of("language", List.of("ru"))))));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate(smartLink(
+                rule(List.of("DateRange"), "https://example.com", Map.of(
+                        "startWith", "2026-12-01T00:00:00",
+                        "endWith", "2026-01-01T00:00:00")))));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate(smartLink(
+                rule(List.of("DeviceType"), "https://example.com",
+                        Map.of("devices", List.of("Console"))))));
+    }
+
+    @Test
+    void rejectsInvalidStructureOutsideHttpBoundary() {
+        SmartLink invalid = smartLink(fallbackRule("javascript:alert(1)"));
+        invalid.setId("bad/id");
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validate(invalid));
+    }
+
+    @Test
+    void rejectsUnreachableRuleAfterFallback() {
+        assertThrows(IllegalArgumentException.class, () -> validator.validate(smartLink(
+                fallbackRule("https://example.com/fallback"),
+                rule(List.of("Language"), "https://example.com/ru",
+                        Map.of("language", List.of("ru"))))));
+    }
+
+    @Test
+    void rejectsIllFormedDateAsClientDefinitionError() {
+        assertThrows(IllegalArgumentException.class, () -> validator.validate(smartLink(
+                rule(List.of("DateRange"), "https://example.com", Map.of(
+                        "startWith", "tomorrow",
+                        "endWith", "later")))));
+    }
+}

--- a/src/test/java/name/krot/smartlinks/service/SmartLinkServiceTest.java
+++ b/src/test/java/name/krot/smartlinks/service/SmartLinkServiceTest.java
@@ -15,6 +15,8 @@ import static name.krot.smartlinks.support.SmartLinksTestFixtures.smartLink;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import name.krot.smartlinks.exception.SmartLinkAlreadyExistsException;
 
 @ExtendWith(MockitoExtension.class)
 class SmartLinkServiceTest {
@@ -24,6 +26,9 @@ class SmartLinkServiceTest {
 
     @Mock
     private SmartLinkRepository smartLinkRepository;
+
+    @Mock
+    private SmartLinkDefinitionValidator definitionValidator;
 
     @Test
     void testGetSmartLinkById() {
@@ -40,9 +45,20 @@ class SmartLinkServiceTest {
     @Test
     void testSaveSmartLink() {
         SmartLink smartLink = smartLink();
+        when(smartLinkRepository.saveIfAbsent(smartLink)).thenReturn(true);
 
         smartLinkService.saveSmartLink(smartLink);
 
-        verify(smartLinkRepository, times(1)).save(smartLink);
+        verify(definitionValidator).validate(smartLink);
+        verify(smartLinkRepository, times(1)).saveIfAbsent(smartLink);
+    }
+
+    @Test
+    void duplicateIdIsRejectedInsteadOfOverwritingExistingRedirects() {
+        SmartLink smartLink = smartLink();
+        when(smartLinkRepository.saveIfAbsent(smartLink)).thenReturn(false);
+
+        assertThrows(SmartLinkAlreadyExistsException.class,
+                () -> smartLinkService.saveSmartLink(smartLink));
     }
 }


### PR DESCRIPTION
## Summary

- validate SmartLink IDs, redirect targets, rule counts/order, predicate names, and predicate-specific arguments at both HTTP and service boundaries
- make link creation write-once with atomic Redis SETNX and return HTTP 409 instead of overwriting an existing redirect
- cache immutable JSON and deserialize fresh objects so callers cannot mutate cached definitions
- distinguish malformed requests, framework HTTP errors, Redis outages, conflicts, and unexpected server failures
- parse weighted/repeated Accept-Language headers and harden date/device predicates and user-agent detection
- add strict JSON parsing limits, Redis timeouts/pooling, exact actuator probes, and working Docker Compose/Kubernetes Redis wiring
- make Gatling seeding unique per run and complete before traffic starts

## Root causes

The repository exposed mutable objects through its L1 cache and used a non-atomic overwrite on create, allowing concurrent or repeated requests to replace a write-once SmartLink. Definitions were only partially validated, malformed predicate arguments could fail later during redirects, and generic exception handling converted framework 404/405 responses into 500s. Language matching treated the complete Accept-Language header as a literal string.

Deployment manifests also rewrote all ingress paths to root, exposed the app service unnecessarily, omitted the Redis workload, and used a single generic health endpoint for both probes.

During review, the load simulations were still seeding fixed IDs in parallel with GET traffic. With write-once semantics, repeat runs would conflict and early GETs could race the seed. Each run now uses a unique ID namespace and starts traffic only after seeding.

## Impact

SmartLinks cannot be silently overwritten, invalid definitions fail before persistence, Redis outages are retryable 503 responses, framework statuses/headers remain intact, routing predicates follow request semantics more accurately, and local/Kubernetes environments have coherent Redis and health contracts.

## Validation

- `.\gradlew.bat --offline clean build jacocoTestReport gatlingClasses --no-daemon`
- 72 test cases: 71 passed, 1 Docker/Testcontainers test skipped locally because the daemon was unavailable
- JaCoCo line coverage: 91.88% (328/357)
- all Gatling simulations compiled with Java 25
- `docker compose config --quiet`
- all Kubernetes YAML documents parsed and required resource metadata verified
- `git diff --check`
- secret scan found no credentials

The GitHub runner will execute the strengthened Redis integration test against its available Docker daemon and validate the committed dependency versions.