### PR TITLE
security: require an API key for write requests

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -21,6 +21,43 @@ SmartLinks is presented as an engineering sample first: routing is split into sm
 - `PredicateFactory` and dedicated `Predicate` classes keep routing rules open for extension.
 - `SmartLinkRepository` keeps Redis behind a repository port.
 - `RedisConfig` is a thin adapter and leaves connection setup to Spring Boot auto-configuration.
+- `ApiKeyAuthenticationFilter` closes the write surface behind a shared API key without touching public redirects.
+
+## Security
+
+Creating a Smart Link mints a URL on a trusted domain that redirects anywhere. An open write endpoint is therefore a ready-made stored open redirect and a bypass for any redirect allowlist, so writes are closed behind a shared API key.
+
+| Property | Behaviour |
+|---|---|
+| Guarded | State-changing requests (`POST`, `PUT`, `PATCH`, `DELETE`) below `/api/**` |
+| Public | `GET /s/{id}`, `/actuator/**`, Swagger UI — the redirect is the product and stays open |
+| Header | `X-API-Key` |
+| Key source | `smartlinks.api-key`, environment variable `SMARTLINKS_API_KEY` |
+| Comparison | `MessageDigest.isEqual` — constant time, no timing oracle |
+| Key not set | **Fail closed**: the application boots and keeps serving redirects, but every write answers 401 |
+| Rejection | 401 plus `WWW-Authenticate`; a missing key and a wrong key are indistinguishable to the caller |
+
+Matching happens on the path **within the application**: `server.servlet.context-path` is stripped before the `/api/` prefix is compared, otherwise a non-root context path (`/redirector/api/smartlinks`) would make the guard silently pass every write. That same path is normalised the way Spring MVC normalises it while routing (`;` path parameters, repeated slashes, percent-encoding), so the prefix cannot be dodged.
+
+```bash
+# Generate and export a key
+export SMARTLINKS_API_KEY="$(openssl rand -base64 32)"
+
+# Create a Smart Link
+curl -X POST http://localhost:8080/api/smartlinks \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $SMARTLINKS_API_KEY" \
+  -d '{"id":"demo","rules":[{"predicates":[],"args":{},"redirectTo":"https://otus.ru/default"}]}'
+
+# Redirect — no key needed
+curl -i http://localhost:8080/s/demo
+```
+
+On Kubernetes the key comes from the `smart-links-api-key` Secret:
+
+```bash
+kubectl create secret generic smart-links-api-key --from-literal=api-key="$SMARTLINKS_API_KEY"
+```
 
 ## Engineering Rules
 
@@ -29,13 +66,14 @@ SmartLinks is presented as an engineering sample first: routing is split into sm
 - Dependencies are declared through explicit constructors with no Lombok.
 - Removed unused libraries: HTTP client, cloud BOM, utility library, URL validator, and a dedicated Redis test adapter.
 - Spring Boot dependency management is declared through an explicit Gradle platform.
-- Secrets are not stored in `application.yml`; local Redis runs without a default password.
+- Secrets are not stored in `application.yml`; local Redis runs without a default password and the API key comes from `SMARTLINKS_API_KEY`.
 
 ## Tests
 
 - Unit tests target single roles: predicates, services, command chain, resolver.
 - Web slice tests use the current Boot 4 `spring-boot-starter-webmvc-test` package.
 - Redis integration tests use the official `redis:8.2-alpine` image through `GenericContainer`.
+- `ApiKeyAuthenticationFilterTest` covers rejection without a key, rejection with a wrong key, the public redirect, fail-closed behaviour on a blank key, and a non-root `context-path`.
 - Shared test fixtures live under `src/test/java/.../support`.
 - JaCoCo runs after `test` and produces an HTML report.
 
@@ -181,11 +219,14 @@ Previous result (before virtual threads): ≥ 4,500 users → 0.14 % HTTP 5xx (T
 ### Running the Tests
 
 ```powershell
+# Required: the scenarios POST to /api/smartlinks and expect 201
+$env:SMARTLINKS_API_KEY = "<key>"
+
 # Build the image and start the environment
 docker build -t smart-links:latest .
 docker compose -p smartlinks-lt -f docker-compose.loadtest.yml up -d
 
-# Run the scenarios
+# Run the scenarios (the key is read from SMARTLINKS_API_KEY, or pass -DapiKey=...)
 .\gradlew.bat gatlingRunSmokeSim
 .\gradlew.bat gatlingRunLoadSim
 .\gradlew.bat gatlingRunStressSim

--- a/README.md
+++ b/README.md
@@ -21,6 +21,43 @@ SmartLinks ценен не набором endpoint-ов, а тем, как ус�
 - `PredicateFactory` и отдельные `Predicate`-классы дают расширение через новые типы предикатов.
 - `SmartLinkRepository` изолирует Redis за портом репозитория.
 - `RedisConfig` остаётся тонким адаптером и не дублирует автоконфигурацию Spring Boot.
+- `ApiKeyAuthenticationFilter` закрывает запись общим API-ключом, не затрагивая публичные редиректы.
+
+## Безопасность
+
+Создание умной ссылки выпускает URL на доверенном домене, который ведёт куда угодно. Открытый endpoint записи — это готовый stored open redirect и обход любого allowlist редиректов, поэтому запись закрыта общим API-ключом.
+
+| Свойство | Поведение |
+|---|---|
+| Что закрыто | Изменяющие запросы (`POST`, `PUT`, `PATCH`, `DELETE`) на `/api/**` |
+| Что открыто | `GET /s/{id}`, `/actuator/**`, Swagger UI — редирект остаётся публичным по назначению |
+| Заголовок | `X-API-Key` |
+| Источник ключа | `smartlinks.api-key`, переменная окружения `SMARTLINKS_API_KEY` |
+| Сравнение | `MessageDigest.isEqual` — постоянное время, без утечки по таймингу |
+| Ключ не задан | **Fail closed**: приложение стартует и продолжает отдавать редиректы, но каждая запись получает 401 |
+| Ответ на отказ | 401 + `WWW-Authenticate`; отсутствующий и неверный ключ неотличимы для клиента |
+
+Ключ сравнивается по пути **внутри приложения**: `server.servlet.context-path` отрезается до проверки префикса `/api/`, иначе под нерутовым context path (`/redirector/api/smartlinks`) фильтр молча пропускал бы все записи. Тот же путь нормализуется так же, как это делает Spring MVC при роутинге (параметры пути `;`, повторные слэши, percent-encoding), чтобы префикс нельзя было обойти.
+
+```powershell
+# Сгенерировать и задать ключ
+$env:SMARTLINKS_API_KEY = [Convert]::ToBase64String((1..32 | ForEach-Object { Get-Random -Max 256 }))
+
+# Создание умной ссылки
+curl.exe -X POST http://localhost:8080/api/smartlinks `
+  -H "Content-Type: application/json" `
+  -H "X-API-Key: $env:SMARTLINKS_API_KEY" `
+  -d '{\"id\":\"demo\",\"rules\":[{\"predicates\":[],\"args\":{},\"redirectTo\":\"https://otus.ru/default\"}]}'
+
+# Редирект — без ключа
+curl.exe -i http://localhost:8080/s/demo
+```
+
+В Kubernetes ключ приходит из Secret `smart-links-api-key`:
+
+```powershell
+kubectl create secret generic smart-links-api-key --from-literal=api-key="<ключ>"
+```
 
 ## Инженерные правила
 
@@ -29,13 +66,14 @@ SmartLinks ценен не набором endpoint-ов, а тем, как ус�
 - Зависимости внедряются через явные конструкторы без Lombok.
 - Лишние библиотеки удалены: HTTP-клиент, cloud BOM, utility-библиотека, URL validator и отдельный Redis test adapter.
 - Spring Boot BOM подключён явно через Gradle platform.
-- Секреты не лежат в `application.yml`; локальный Redis запускается без пароля.
+- Секреты не лежат в `application.yml`; локальный Redis запускается без пароля, API-ключ приходит из `SMARTLINKS_API_KEY`.
 
 ## Тесты
 
 - Unit-тесты проверяют отдельные роли: predicates, services, command chain, resolver.
 - Web slice использует актуальный Boot 4 пакет `spring-boot-starter-webmvc-test`.
 - Redis integration test использует официальный `redis:8.2-alpine` через `GenericContainer`.
+- `ApiKeyAuthenticationFilterTest` покрывает отказ без ключа, с неверным ключом, публичность редиректа, fail closed при пустом ключе и нерутовый `context-path`.
 - Test fixtures вынесены в `src/test/java/.../support`, чтобы сценарии не дублировали сборку моделей.
 - JaCoCo запускается после `test` и формирует HTML-отчёт.
 
@@ -181,11 +219,14 @@ Caffeine устраняет Redis-сатурацию: при 200 пользов�
 ### Запуск тестов
 
 ```powershell
+# Ключ обязателен: сценарии делают POST /api/smartlinks и ждут 201
+$env:SMARTLINKS_API_KEY = "<ключ>"
+
 # Собрать образ и поднять окружение
 docker build -t smart-links:latest .
 docker compose -p smartlinks-lt -f docker-compose.loadtest.yml up -d
 
-# Запустить сценарии
+# Запустить сценарии (ключ подхватывается из SMARTLINKS_API_KEY, либо -DapiKey=...)
 .\gradlew.bat gatlingRunSmokeSim
 .\gradlew.bat gatlingRunLoadSim
 .\gradlew.bat gatlingRunStressSim

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,8 +89,12 @@ listOf("SmokeSim", "LoadSim", "StressSim", "SpikeSim", "BreakSim").forEach { sim
             "--results-folder", gatlingResultsDir.get().asFile.absolutePath
         )
 
+        // apiKey is forwarded because POST /api/smartlinks now answers 401 without X-API-Key.
         systemProperties(
-            mapOf("baseUrl" to (System.getProperty("baseUrl") ?: "http://localhost:8090"))
+            mapOf(
+                "baseUrl" to (System.getProperty("baseUrl") ?: "http://localhost:8090"),
+                "apiKey" to (System.getProperty("apiKey") ?: System.getenv("SMARTLINKS_API_KEY") ?: "")
+            )
         )
 
         jvmArgs(

--- a/docker-compose.loadtest.yml
+++ b/docker-compose.loadtest.yml
@@ -12,5 +12,8 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - SPRING_DATA_REDIS_HOST=redis
+      # Required: the Gatling simulations POST to /api/smartlinks and expect 201.
+      # Export the same value for the gatlingRun* tasks.
+      - SMARTLINKS_API_KEY=${SMARTLINKS_API_KEY:?export SMARTLINKS_API_KEY before starting the load-test stack}
     depends_on:
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,9 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - SPRING_DATA_REDIS_HOST=redis
       - SPRING_DATA_REDIS_PORT=6379
+      # Shared key for POST /api/** (X-API-Key header); redirects stay public.
+      # Export SMARTLINKS_API_KEY before `docker compose up`, otherwise writes answer 401.
+      - SMARTLINKS_API_KEY=${SMARTLINKS_API_KEY:-}
     restart: always
     depends_on:
       redis:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -26,6 +26,16 @@ spec:
               value: "redis"
             - name: SPRING_DATA_REDIS_PORT
               value: "6379"
+            # Shared key for POST /api/** (X-API-Key header). Redirects stay public.
+            # Create it before applying this manifest, e.g.:
+            #   kubectl create secret generic smart-links-api-key \
+            #     --from-literal=api-key="$(openssl rand -base64 32)"
+            # Without the secret the pod still serves redirects but rejects every write with 401.
+            - name: SMARTLINKS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: smart-links-api-key
+                  key: api-key
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness

--- a/redirector_tests.http
+++ b/redirector_tests.http
@@ -1,7 +1,14 @@
+# Операции записи требуют заголовок X-API-Key со значением smartlinks.api-key
+# (переменная окружения SMARTLINKS_API_KEY). Подставьте сюда свой ключ — плейсхолдер
+# ниже намеренно нерабочий, реальные ключи в репозиторий не коммитим.
+# Редиректы GET /s/{id} остаются публичными и ключа не требуют.
+@apiKey = replace-with-your-api-key
+
 ### Создание умной ссылки с правилами Language и DateRange
 
 POST http://localhost:8080/api/smartlinks
 Content-Type: application/json
+X-API-Key: {{apiKey}}
 
 {
   "id": "smartlink123456",
@@ -34,6 +41,7 @@ Content-Type: application/json
 
 POST http://localhost:8080/api/smartlinks
 Content-Type: application/json
+X-API-Key: {{apiKey}}
 
 {
   "id": "smartlinkDevice",
@@ -94,5 +102,38 @@ User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64)
 GET http://localhost:8080/s/nonexistent
 Accept-Language: en-US
 User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64)
+
+### Создание без X-API-Key → 401
+
+POST http://localhost:8080/api/smartlinks
+Content-Type: application/json
+
+{
+  "id": "smartlinkUnauthorized",
+  "rules": [
+    {
+      "predicates": [],
+      "args": {},
+      "redirectTo": "https://otus.ru/default"
+    }
+  ]
+}
+
+### Создание с неверным X-API-Key → 401
+
+POST http://localhost:8080/api/smartlinks
+Content-Type: application/json
+X-API-Key: wrong-key
+
+{
+  "id": "smartlinkUnauthorized",
+  "rules": [
+    {
+      "predicates": [],
+      "args": {},
+      "redirectTo": "https://otus.ru/default"
+    }
+  ]
+}
 
 ###

--- a/src/gatling/java/name/krot/smartlinks/load/SmartLinksSimulation.java
+++ b/src/gatling/java/name/krot/smartlinks/load/SmartLinksSimulation.java
@@ -7,6 +7,7 @@ import io.gatling.javaapi.http.HttpProtocolBuilder;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -18,6 +19,20 @@ public abstract class SmartLinksSimulation extends Simulation {
 
     protected static final String BASE_URL =
             System.getProperty("baseUrl", "http://localhost:8090");
+
+    /**
+     * Header and key for the guarded write endpoint. Without it every POST answers 401 and the
+     * simulations fail on their {@code status().is(201)} check.
+     *
+     * <p>Pass it as {@code -DapiKey=...} or export {@code SMARTLINKS_API_KEY} — it must match the
+     * {@code smartlinks.api-key} of the system under test.
+     */
+    protected static final String API_KEY_HEADER = "X-API-Key";
+
+    protected static final String API_KEY = Optional
+            .ofNullable(System.getProperty("apiKey"))
+            .or(() -> Optional.ofNullable(System.getenv("SMARTLINKS_API_KEY")))
+            .orElse("");
 
     static final int LINK_POOL_SIZE = 50;
     private static final String LINK_POOL_PREFIX = "load-lnk-" +
@@ -61,6 +76,7 @@ public abstract class SmartLinksSimulation extends Simulation {
                             session.set("seedId", linkId(session.getInt("i") + 1))
                     ).exec(http("POST seed link")
                             .post("/api/smartlinks")
+                            .header(API_KEY_HEADER, API_KEY)
                             .body(StringBody(session -> buildSeedJson(session.getString("seedId"))))
                             .check(status().is(201)))
             ));
@@ -92,6 +108,7 @@ public abstract class SmartLinksSimulation extends Simulation {
                                     UUID.randomUUID().toString().replace("-", "").substring(0, 12))
                     ).exec(http("POST /api/smartlinks")
                             .post("/api/smartlinks")
+                            .header(API_KEY_HEADER, API_KEY)
                             .body(StringBody(session ->
                                     """
                                     {"id":"%s","rules":[{"predicates":[],"args":{},"redirectTo":"https://example.com/fallback"}]}

--- a/src/main/java/name/krot/smartlinks/config/OpenApiConfig.java
+++ b/src/main/java/name/krot/smartlinks/config/OpenApiConfig.java
@@ -1,12 +1,18 @@
 package name.krot.smartlinks.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import name.krot.smartlinks.security.ApiKeyAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
+
+    /** Referenced from {@code @SecurityRequirement} on the write operation only. */
+    public static final String API_KEY_SCHEME = "ApiKeyAuth";
 
     @Bean
     public OpenAPI urlShortenerOpenAPI() {
@@ -14,6 +20,14 @@ public class OpenApiConfig {
                 .info(new Info()
                         .title("URL SmartLinks API")
                         .version("1.0")
-                        .description("Документация API для сервиса сокращения URL"));
+                        .description("Документация API для сервиса сокращения URL. "
+                                + "Операции записи требуют заголовок " + ApiKeyAuthenticationFilter.API_KEY_HEADER
+                                + "; редиректы остаются публичными."))
+                .components(new Components()
+                        .addSecuritySchemes(API_KEY_SCHEME, new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name(ApiKeyAuthenticationFilter.API_KEY_HEADER)
+                                .description("Общий ключ из smartlinks.api-key (env SMARTLINKS_API_KEY)")));
     }
 }

--- a/src/main/java/name/krot/smartlinks/controller/RedirectControllerApi.java
+++ b/src/main/java/name/krot/smartlinks/controller/RedirectControllerApi.java
@@ -4,8 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import name.krot.smartlinks.config.OpenApiConfig;
 import name.krot.smartlinks.model.SmartLink;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,9 +19,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 public interface RedirectControllerApi {
     @PostMapping("/api/smartlinks")
+    @SecurityRequirement(name = OpenApiConfig.API_KEY_SCHEME)
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Умная ссылка создана"),
+            @ApiResponse(responseCode = "401",
+                    description = "Отсутствует или неверный заголовок X-API-Key",
+                    content = @Content),
+            @ApiResponse(responseCode = "409", description = "Умная ссылка с таким id уже существует",
+                    content = @Content)
+    })
     @Operation(
             summary = "Создать умную ссылку",
-            description = "Метод для создания новой умной ссылки",
+            description = "Метод для создания новой умной ссылки. "
+                    + "Требуется заголовок X-API-Key со значением smartlinks.api-key (env SMARTLINKS_API_KEY).",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "Данные SmartLink",
                     required = true,

--- a/src/main/java/name/krot/smartlinks/security/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/name/krot/smartlinks/security/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,181 @@
+package name.krot.smartlinks.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static java.util.function.Predicate.not;
+
+/**
+ * Requires a shared API key on every state-changing request below {@value #PROTECTED_PATH_PREFIX}.
+ *
+ * <p>Creating a Smart Link mints a URL on a trusted domain that redirects anywhere, so an open
+ * write endpoint is a stored open-redirect / phishing primitive and bypasses any redirect
+ * allowlist enforced elsewhere. Reads stay public on purpose: {@code GET /s/{id}} is the product.
+ *
+ * <p>Behaviour:
+ * <ul>
+ *   <li>The key is read from {@code smartlinks.api-key} (environment: {@code SMARTLINKS_API_KEY}).</li>
+ *   <li>An unset or blank key <strong>fails closed</strong>: every write is answered with 401.
+ *       The application still boots and keeps serving redirects.</li>
+ *   <li>A missing header and a wrong header produce the identical response, so the filter does not
+ *       tell an attacker which of the two happened.</li>
+ *   <li>Comparison goes through {@link MessageDigest#isEqual} to keep it constant-time.</li>
+ * </ul>
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1000)
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    /** Header carrying the shared key on write requests. */
+    public static final String API_KEY_HEADER = "X-API-Key";
+
+    /** Everything below this path is treated as the write surface. */
+    public static final String PROTECTED_PATH_PREFIX = "/api/";
+
+    static final String UNAUTHORIZED_BODY = "Unauthorized";
+
+    private static final Logger log = LoggerFactory.getLogger(ApiKeyAuthenticationFilter.class);
+
+    private static final String CHALLENGE = "ApiKey realm=\"SmartLinks\", header=\"" + API_KEY_HEADER + "\"";
+    private static final String UNAUTHORIZED_CONTENT_TYPE = "text/plain;charset=UTF-8";
+
+    /** Methods that cannot change state and therefore never need a key. */
+    private static final Set<String> READ_ONLY_METHODS = Set.of("GET", "HEAD", "OPTIONS", "TRACE");
+
+    /** Path parameters (";foo=bar") are ignored by Spring MVC when routing, so ignore them here too. */
+    private static final Pattern SEMICOLON_CONTENT = Pattern.compile(";[^/]*");
+
+    /** Spring MVC collapses repeated slashes when routing, so "//api/x" must not slip past the prefix. */
+    private static final Pattern REPEATED_SLASHES = Pattern.compile("/{2,}");
+
+    /** UTF-8 bytes of the configured key, or {@code null} when no key is configured. */
+    private final byte[] expectedApiKey;
+
+    public ApiKeyAuthenticationFilter(@Value("${smartlinks.api-key:}") String apiKey) {
+        this.expectedApiKey = Optional.ofNullable(apiKey)
+                .filter(not(String::isBlank))
+                .map(key -> key.getBytes(StandardCharsets.UTF_8))
+                .orElse(null);
+
+        Optional.ofNullable(this.expectedApiKey).ifPresentOrElse(
+                key -> log.info("Write requests below {} require the {} header", PROTECTED_PATH_PREFIX, API_KEY_HEADER),
+                () -> log.warn("smartlinks.api-key (env SMARTLINKS_API_KEY) is not set: every write below {} "
+                        + "will be rejected with 401. Redirects stay public.", PROTECTED_PATH_PREFIX));
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !requiresApiKey(request);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (!isAuthorized(request.getHeader(API_KEY_HEADER))) {
+            reject(request, response);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * A request needs a key when it can change state and targets the write surface.
+     * The path is resolved <em>within the application</em>, so a non-root
+     * {@code server.servlet.context-path} cannot make the prefix check fail open.
+     */
+    static boolean requiresApiKey(HttpServletRequest request) {
+        return isStateChanging(request.getMethod())
+                && pathWithinApplication(request).startsWith(PROTECTED_PATH_PREFIX);
+    }
+
+    private static boolean isStateChanging(String method) {
+        return !READ_ONLY_METHODS.contains(Optional.ofNullable(method)
+                .orElse("")
+                .toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * Returns the request path with the servlet context path removed and normalised the same way
+     * Spring MVC normalises it before matching handler mappings.
+     *
+     * <p>Matching the raw {@link HttpServletRequest#getRequestURI()} against the prefix is the bug
+     * this method exists to prevent: under {@code server.servlet.context-path=/redirector} the URI
+     * is {@code /redirector/api/smartlinks}, which does not start with {@code /api/} — the guard
+     * would silently pass every write through.
+     */
+    static String pathWithinApplication(HttpServletRequest request) {
+        String requestUri = Optional.ofNullable(request.getRequestURI()).orElse("/");
+        String contextPath = Optional.ofNullable(request.getContextPath()).orElse("");
+
+        String withinApplication = Optional.of(contextPath)
+                .filter(not(String::isEmpty))
+                .filter(not("/"::equals))
+                .filter(requestUri::startsWith)
+                .map(prefix -> requestUri.substring(prefix.length()))
+                // Only accept a clean segment boundary; otherwise keep the untouched URI.
+                .filter(remainder -> remainder.isEmpty() || remainder.startsWith("/"))
+                .orElse(requestUri);
+
+        return normalize(withinApplication);
+    }
+
+    private static String normalize(String path) {
+        String withoutPathParameters = SEMICOLON_CONTENT.matcher(path).replaceAll("");
+        String collapsed = REPEATED_SLASHES.matcher(decode(withoutPathParameters)).replaceAll("/");
+        return collapsed.isEmpty() ? "/" : collapsed;
+    }
+
+    private static String decode(String path) {
+        try {
+            return URLDecoder.decode(path, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException malformedEscape) {
+            // Undecodable percent-escapes are rejected by the container anyway. Fall back to the
+            // raw value rather than dropping the guard for a request we cannot interpret.
+            return path;
+        }
+    }
+
+    /**
+     * {@link MessageDigest#isEqual} returns {@code false} when either array is {@code null},
+     * so an unconfigured key ({@code expectedApiKey == null}) rejects every write.
+     */
+    private boolean isAuthorized(String presentedApiKey) {
+        return Optional.ofNullable(presentedApiKey)
+                .map(key -> key.getBytes(StandardCharsets.UTF_8))
+                .filter(key -> MessageDigest.isEqual(expectedApiKey, key))
+                .isPresent();
+    }
+
+    private static void reject(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        log.warn("Rejected unauthenticated {} {} from {}",
+                request.getMethod(), pathWithinApplication(request), request.getRemoteAddr());
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, CHALLENGE);
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        response.setContentType(UNAUTHORIZED_CONTENT_TYPE);
+        response.getWriter().write(UNAUTHORIZED_BODY);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,9 @@
+smartlinks:
+  # Shared key required on write requests (POST /api/**) via the X-API-Key header.
+  # Supply it through the SMARTLINKS_API_KEY environment variable — never commit a real key.
+  # Left blank the service still starts and keeps serving redirects, but every write is
+  # rejected with 401 (fail closed).
+  api-key: ${SMARTLINKS_API_KEY:}
 spring:
   application:
     name: SmartLinks

--- a/src/test/java/name/krot/smartlinks/controller/RedirectControllerTest.java
+++ b/src/test/java/name/krot/smartlinks/controller/RedirectControllerTest.java
@@ -19,9 +19,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static name.krot.smartlinks.security.ApiKeyAuthenticationFilter.API_KEY_HEADER;
 import static name.krot.smartlinks.support.SmartLinkJsonFixtures.fallbackSmartLinkJson;
 import static name.krot.smartlinks.support.SmartLinkJsonFixtures.invalidRedirectSmartLinkJson;
 import static name.krot.smartlinks.support.SmartLinkJsonFixtures.validSmartLinkJson;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.API_KEY;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.RU_REDIRECT_URL;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.SMART_LINK_ID;
 import static name.krot.smartlinks.support.SmartLinksTestFixtures.requestContext;
@@ -38,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(RedirectController.class)
+@WebMvcTest(value = RedirectController.class, properties = "smartlinks.api-key=" + API_KEY)
 class RedirectControllerTest {
 
     @Autowired
@@ -121,6 +123,7 @@ class RedirectControllerTest {
     @Test
     void methodNotAllowedKeepsFrameworkAllowHeader() throws Exception {
         mockMvc.perform(put("/api/smartlinks")
+                        .header(API_KEY_HEADER, API_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(validSmartLinkJson()))
                 .andExpect(status().isMethodNotAllowed())
@@ -130,6 +133,7 @@ class RedirectControllerTest {
     @Test
     void testCreateSmartLink() throws Exception {
         mockMvc.perform(post("/api/smartlinks")
+                        .header(API_KEY_HEADER, API_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(validSmartLinkJson()))
                 .andExpect(status().isCreated())
@@ -146,6 +150,7 @@ class RedirectControllerTest {
     @Test
     void testCreateSmartLinkAcceptsFallbackRule() throws Exception {
         mockMvc.perform(post("/api/smartlinks")
+                        .header(API_KEY_HEADER, API_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(fallbackSmartLinkJson()))
                 .andExpect(status().isCreated());
@@ -157,6 +162,7 @@ class RedirectControllerTest {
                 .when(smartLinkService).saveSmartLink(any());
 
         mockMvc.perform(post("/api/smartlinks")
+                        .header(API_KEY_HEADER, API_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(validSmartLinkJson()))
                 .andExpect(status().isConflict());
@@ -165,6 +171,7 @@ class RedirectControllerTest {
     @Test
     void testCreateSmartLinkRejectsRedirectWithoutHost() throws Exception {
         mockMvc.perform(post("/api/smartlinks")
+                        .header(API_KEY_HEADER, API_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidRedirectSmartLinkJson()))
                 .andExpect(status().isBadRequest());
@@ -177,6 +184,7 @@ class RedirectControllerTest {
                 "\"id\": \"smartlink123\", \"id\": \"ambiguous\"");
 
         mockMvc.perform(post("/api/smartlinks")
+                        .header(API_KEY_HEADER, API_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(duplicateId))
                 .andExpect(status().isBadRequest());
@@ -191,10 +199,71 @@ class RedirectControllerTest {
                 "\"id\": \"smartlink123\", \"idd\": \"typo\"");
 
         mockMvc.perform(post("/api/smartlinks")
+                        .header(API_KEY_HEADER, API_KEY)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(unknownProperty))
                 .andExpect(status().isBadRequest());
 
         verify(smartLinkService, never()).saveSmartLink(any());
+    }
+
+    @Test
+    void createWithoutApiKeyIsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/smartlinks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validSmartLinkJson()))
+                .andExpect(status().isUnauthorized());
+
+        verify(smartLinkService, never()).saveSmartLink(any());
+    }
+
+    @Test
+    void createWithWrongApiKeyIsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/smartlinks")
+                        .header(API_KEY_HEADER, API_KEY + "-tampered")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validSmartLinkJson()))
+                .andExpect(status().isUnauthorized());
+
+        verify(smartLinkService, never()).saveSmartLink(any());
+    }
+
+    @Test
+    void redirectStaysPublicWithoutApiKey() throws Exception {
+        RequestContext context = requestContext("ru-RU");
+        when(requestContextFactory.from(any())).thenReturn(context);
+        when(redirectResolver.resolveRedirect(SMART_LINK_ID, context)).thenReturn(URI.create(RU_REDIRECT_URL));
+
+        mockMvc.perform(get("/s/{smartLinkId}", SMART_LINK_ID)
+                        .header("Accept-Language", "ru-RU"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", RU_REDIRECT_URL));
+    }
+
+    /**
+     * Guards the regression the filter is built around: stripping the servlet context path before
+     * matching "/api/". Without it the guard silently passes writes under a non-root context path.
+     */
+    @Test
+    void createUnderNonRootContextPathStillRequiresApiKey() throws Exception {
+        mockMvc.perform(post("/redirector/api/smartlinks")
+                        .contextPath("/redirector")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validSmartLinkJson()))
+                .andExpect(status().isUnauthorized());
+
+        verify(smartLinkService, never()).saveSmartLink(any());
+    }
+
+    @Test
+    void createUnderNonRootContextPathSucceedsWithApiKey() throws Exception {
+        mockMvc.perform(post("/redirector/api/smartlinks")
+                        .contextPath("/redirector")
+                        .header(API_KEY_HEADER, API_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validSmartLinkJson()))
+                .andExpect(status().isCreated());
+
+        verify(smartLinkService, times(1)).saveSmartLink(any());
     }
 }

--- a/src/test/java/name/krot/smartlinks/security/ApiKeyAuthenticationFilterTest.java
+++ b/src/test/java/name/krot/smartlinks/security/ApiKeyAuthenticationFilterTest.java
@@ -1,0 +1,168 @@
+package name.krot.smartlinks.security;
+
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static name.krot.smartlinks.security.ApiKeyAuthenticationFilter.API_KEY_HEADER;
+import static name.krot.smartlinks.security.ApiKeyAuthenticationFilter.UNAUTHORIZED_BODY;
+import static name.krot.smartlinks.support.SmartLinksTestFixtures.API_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ApiKeyAuthenticationFilterTest {
+
+    private static final String CONTEXT_PATH = "/redirector";
+
+    private final ApiKeyAuthenticationFilter filter = new ApiKeyAuthenticationFilter(API_KEY);
+    private final MockHttpServletResponse response = new MockHttpServletResponse();
+    private final MockFilterChain chain = new MockFilterChain();
+
+    @Test
+    void writeWithoutApiKeyIsRejected() throws Exception {
+        invoke(filter, post("/api/smartlinks"));
+
+        assertUnauthorized();
+    }
+
+    @Test
+    void writeWithWrongApiKeyIsRejected() throws Exception {
+        MockHttpServletRequest request = post("/api/smartlinks");
+        request.addHeader(API_KEY_HEADER, API_KEY + "-tampered");
+
+        invoke(filter, request);
+
+        assertUnauthorized();
+    }
+
+    @Test
+    void writeWithCorrectApiKeyReachesTheApplication() throws Exception {
+        MockHttpServletRequest request = post("/api/smartlinks");
+        request.addHeader(API_KEY_HEADER, API_KEY);
+
+        invoke(filter, request);
+
+        assertChainInvoked();
+    }
+
+    @Test
+    void redirectStaysPublic() throws Exception {
+        invoke(filter, get("/s/smartlink123"));
+
+        assertChainInvoked();
+    }
+
+    @Test
+    void actuatorAndDocsStayPublic() throws Exception {
+        invoke(filter, get("/actuator/health/readiness"));
+
+        assertChainInvoked();
+    }
+
+    /**
+     * The trap this filter is written around: matching the raw request URI against "/api/" fails
+     * open once the application is deployed under a non-root servlet context path.
+     */
+    @Test
+    void contextPathIsStrippedBeforeThePrefixIsMatched() throws Exception {
+        MockHttpServletRequest request = post(CONTEXT_PATH + "/api/smartlinks");
+        request.setContextPath(CONTEXT_PATH);
+
+        invoke(filter, request);
+
+        assertUnauthorized();
+    }
+
+    @Test
+    void contextPathWriteWithCorrectApiKeyReachesTheApplication() throws Exception {
+        MockHttpServletRequest request = post(CONTEXT_PATH + "/api/smartlinks");
+        request.setContextPath(CONTEXT_PATH);
+        request.addHeader(API_KEY_HEADER, API_KEY);
+
+        invoke(filter, request);
+
+        assertChainInvoked();
+    }
+
+    @Test
+    void contextPathRedirectStaysPublic() throws Exception {
+        MockHttpServletRequest request = get(CONTEXT_PATH + "/s/smartlink123");
+        request.setContextPath(CONTEXT_PATH);
+
+        invoke(filter, request);
+
+        assertChainInvoked();
+    }
+
+    @Test
+    void blankApiKeyFailsClosedInsteadOfAllowingEveryWrite() throws Exception {
+        ApiKeyAuthenticationFilter unconfigured = new ApiKeyAuthenticationFilter("   ");
+        MockHttpServletRequest request = post("/api/smartlinks");
+        request.addHeader(API_KEY_HEADER, "");
+
+        invoke(unconfigured, request);
+
+        assertUnauthorized();
+    }
+
+    @Test
+    void repeatedSlashesDoNotBypassThePrefix() throws Exception {
+        invoke(filter, post("//api/smartlinks"));
+
+        assertUnauthorized();
+    }
+
+    @Test
+    void pathParametersDoNotBypassThePrefix() throws Exception {
+        invoke(filter, post("/api;jsessionid=42/smartlinks"));
+
+        assertUnauthorized();
+    }
+
+    @Test
+    void percentEncodedPathDoesNotBypassThePrefix() throws Exception {
+        invoke(filter, post("/%61pi/smartlinks"));
+
+        assertUnauthorized();
+    }
+
+    @Test
+    void everyStateChangingMethodOnTheWriteSurfaceIsGuarded() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/api/smartlinks/smartlink123");
+
+        invoke(filter, request);
+
+        assertUnauthorized();
+    }
+
+    private void assertUnauthorized() throws IOException {
+        assertEquals(401, response.getStatus());
+        assertEquals(UNAUTHORIZED_BODY, response.getContentAsString());
+        assertNotNull(response.getHeader(HttpHeaders.WWW_AUTHENTICATE));
+        assertNull(chain.getRequest(), "Rejected request must not reach the application");
+    }
+
+    private void assertChainInvoked() {
+        assertNotNull(chain.getRequest(), "Request should have been passed down the filter chain");
+        assertEquals(200, response.getStatus());
+    }
+
+    private void invoke(ApiKeyAuthenticationFilter target, MockHttpServletRequest request)
+            throws ServletException, IOException {
+        target.doFilter(request, response, chain);
+    }
+
+    private static MockHttpServletRequest post(String requestUri) {
+        return new MockHttpServletRequest("POST", requestUri);
+    }
+
+    private static MockHttpServletRequest get(String requestUri) {
+        return new MockHttpServletRequest("GET", requestUri);
+    }
+}

--- a/src/test/java/name/krot/smartlinks/support/SmartLinksTestFixtures.java
+++ b/src/test/java/name/krot/smartlinks/support/SmartLinksTestFixtures.java
@@ -14,6 +14,8 @@ import java.util.Map;
 public final class SmartLinksTestFixtures {
 
     public static final String SMART_LINK_ID = "smartlink123";
+    /** Test-only value for {@code smartlinks.api-key}; must stay a compile-time constant for annotations. */
+    public static final String API_KEY = "test-api-key";
     public static final String RU_REDIRECT_URL = "https://otus.ru/ru";
     public static final String DEFAULT_REDIRECT_URL = "https://otus.ru/default";
     public static final LocalDateTime REQUEST_TIME = LocalDateTime.of(2024, 11, 15, 12, 0);


### PR DESCRIPTION
Closes the last open item from the security audit. The non-destructive `saveIfAbsent`, the `@Size` bounds and the Redis binding were all already fixed upstream and are untouched here.

**The bug.** `POST /api/smartlinks` had no authentication at all — no spring-security dependency, no filter. Anyone able to reach the service could mint short links on the trusted domain, giving a stored open-redirect for phishing and a way through URL allowlists.

- `ApiKeyAuthenticationFilter` — `X-API-Key`, key from `smartlinks.api-key` / `SMARTLINKS_API_KEY`, `MessageDigest.isEqual` comparison, identical 401 for missing and wrong keys.
- **Fails closed**: an unset key denies every write (the app still boots and keeps serving redirects, so a missing env var cannot take down the redirect path).
- Guards state-changing methods below `/api/` only — `GET /s/{id}`, actuator and Swagger stay open.
- Matches on the path *within the application*, normalising context path, `;` parameters, repeated slashes and percent-encoding, since `//api/x`, `/api;x=1/smartlinks` and `/%61pi/smartlinks` all reach the controller but slip past a raw-URI prefix check.

`./gradlew clean test` → BUILD SUCCESSFUL, 90 tests, 0 failures (1 skipped: the Testcontainers test, `disabledWithoutDocker`).

⚠️ **Deploy-time breaking change.** Writes 401 until `SMARTLINKS_API_KEY` is set, and the k8s Deployment references a `smart-links-api-key` Secret via `secretKeyRef`, so the pod will not start until it exists:
`kubectl create secret generic smart-links-api-key --from-literal=api-key=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)