### PR TITLE
Publish only tested images, drop root in the container, quiet prod logs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,10 @@ jobs:
       - name: Change wrapper permissions
         run: chmod +x ./gradlew
 
-      - name: Package application JAR
-        run: ./gradlew bootJar --no-daemon -x test
+      # Именно `build`, а не `bootJar -x test`: workflow идёт на тот же push, что и тесты,
+      # но независимо от него, поэтому с `-x test` в GHCR уезжал бы образ с красными тестами.
+      - name: Build and test application JAR
+        run: ./gradlew build --no-daemon
 
       - name: Prepare Docker context
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,12 @@ FROM eclipse-temurin:25-jre@sha256:7ea65de6187ad8fbcc0ad155950c38664a7371148bb3c
 
 WORKDIR /app
 
-COPY --from=build /workspace/app.jar app.jar
+# Сервис ничего не пишет на диск, поэтому root ему не нужен ни для чего.
+RUN useradd --system --uid 10001 --user-group --no-create-home --shell /usr/sbin/nologin app
+
+COPY --from=build --chown=app:app /workspace/app.jar app.jar
+
+USER app
 
 EXPOSE 8080
 

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -3,7 +3,12 @@ FROM eclipse-temurin:25-jre@sha256:7ea65de6187ad8fbcc0ad155950c38664a7371148bb3c
 
 WORKDIR /app
 
-COPY app.jar app.jar
+# Сервис ничего не пишет на диск, поэтому root ему не нужен ни для чего.
+RUN useradd --system --uid 10001 --user-group --no-create-home --shell /usr/sbin/nologin app
+
+COPY --chown=app:app app.jar app.jar
+
+USER app
 
 EXPOSE 8080
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 volumes:
   redis_data:
-  gradle_cache25:
 services:
   redis:
     container_name: redis
@@ -23,8 +22,8 @@ services:
     image: smart-links:latest
     ports:
       - "8080:8080"
-    volumes:
-      - gradle_cache25:/home/gradle/.gradle
+    # Тома с кешем Gradle тут не было смысла держать: сборка идёт внутри образа (BuildKit
+    # тома compose не видит), а в рантайме это JRE-слой без Gradle вообще.
     environment:
       - SPRING_PROFILES_ACTIVE=dev
       - SPRING_DATA_REDIS_HOST=redis

--- a/src/main/java/name/krot/smartlinks/controller/GlobalExceptionHandler.java
+++ b/src/main/java/name/krot/smartlinks/controller/GlobalExceptionHandler.java
@@ -35,7 +35,10 @@ public class GlobalExceptionHandler {
                     ? fieldError.getField()
                     : objectErrorKey(error);
             String errorMessage = error.getDefaultMessage();
-            errors.put(fieldName, errorMessage);
+            // Одно поле легко нарушает два правила сразу (@NotBlank и @Pattern):
+            // put затирал первое сообщение вторым, и клиент видел только половину причины.
+            errors.merge(fieldName, errorMessage,
+                    (existing, added) -> existing.equals(added) ? existing : existing + "; " + added);
         });
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }

--- a/src/main/java/name/krot/smartlinks/controller/RedirectController.java
+++ b/src/main/java/name/krot/smartlinks/controller/RedirectController.java
@@ -47,7 +47,10 @@ public class RedirectController implements RedirectControllerApi {
         if (!SmartLink.isValidId(smartLinkId)) {
             throw new IllegalArgumentException("Smart Link id contains unsupported characters or is too long");
         }
-        log.info("Received GET request, smartLinkId: {}, HttpServletRequest: {}", smartLinkId, request);
+        // Публичный редирект — горячий путь: строка на каждый запрос уходит в debug.
+        // Сам HttpServletRequest в лог не годится: toString у реализации Tomcat —
+        // это `RequestFacade@1f2a3b4`, полезного в нём ничего нет.
+        log.debug("Received GET request, smartLinkId: {}, query: {}", smartLinkId, request.getQueryString());
         URI redirectUri = redirectResolver.resolveRedirect(smartLinkId, requestContextFactory.from(request));
         return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
     }

--- a/src/main/java/name/krot/smartlinks/controller/RedirectController.java
+++ b/src/main/java/name/krot/smartlinks/controller/RedirectController.java
@@ -48,9 +48,10 @@ public class RedirectController implements RedirectControllerApi {
             throw new IllegalArgumentException("Smart Link id contains unsupported characters or is too long");
         }
         // Публичный редирект — горячий путь: строка на каждый запрос уходит в debug.
-        // Сам HttpServletRequest в лог не годится: toString у реализации Tomcat —
-        // это `RequestFacade@1f2a3b4`, полезного в нём ничего нет.
-        log.debug("Received GET request, smartLinkId: {}, query: {}", smartLinkId, request.getQueryString());
+        // В лог идёт только идентификатор ссылки: HttpServletRequest бесполезен (у реализации
+        // Tomcat toString — это `RequestFacade@1f2a3b4`), а query string задаёт кто угодно,
+        // и токены или адреса почты из неё оседали бы в журнале.
+        log.debug("Received GET request, smartLinkId: {}", smartLinkId);
         URI redirectUri = redirectResolver.resolveRedirect(smartLinkId, requestContextFactory.from(request));
         return ResponseEntity.status(HttpStatus.FOUND).location(redirectUri).build();
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+# Профиль dev (docker-compose.yml задаёт SPRING_PROFILES_ACTIVE=dev).
+# До его появления SPRING_PROFILES_ACTIVE не значил ничего: файлов профилей не было,
+# а отладочный уровень стоял в базовом application.yml и уезжал в прод.
+logging:
+  level:
+    name.krot.smartlinks: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,8 @@ management:
 logging:
   level:
     root: INFO
-    name.krot.smartlinks: DEBUG
+    # DEBUG включает профиль dev (docker-compose.yml): в k8s стоит SPRING_PROFILES_ACTIVE=prod,
+    # и отладочный уровень на публичном редиректе там не нужен.
+    name.krot.smartlinks: INFO
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"

--- a/src/test/java/name/krot/smartlinks/controller/GlobalExceptionHandlerTest.java
+++ b/src/test/java/name/krot/smartlinks/controller/GlobalExceptionHandlerTest.java
@@ -4,11 +4,17 @@ import name.krot.smartlinks.exception.NoMatchingRuleException;
 import name.krot.smartlinks.exception.ResourceNotFoundException;
 import name.krot.smartlinks.exception.SmartLinkNotFoundException;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -88,6 +94,27 @@ class GlobalExceptionHandlerTest {
         assertEquals(503, response.getStatusCode().value());
         assertEquals("1", response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER));
         assertEquals("Storage temporarily unavailable", response.getBody());
+    }
+
+    @Test
+    void allValidationMessagesOfOneFieldSurvive() throws NoSuchMethodException {
+        BeanPropertyBindingResult binding = new BeanPropertyBindingResult(new Object(), "smartLink");
+        binding.addError(new FieldError("smartLink", "id", "must not be blank"));
+        binding.addError(new FieldError("smartLink", "id", "must match the id pattern"));
+        MethodParameter parameter = new MethodParameter(
+                GlobalExceptionHandlerTest.class.getDeclaredMethod("validationSample", String.class), 0);
+
+        ResponseEntity<Map<String, String>> response = exceptionHandler.handleValidationExceptions(
+                new MethodArgumentNotValidException(parameter, binding));
+
+        assertEquals(400, response.getStatusCode().value());
+        // Раньше второе сообщение затирало первое, и клиент видел половину причины
+        assertEquals("must not be blank; must match the id pattern",
+                response.getBody().get("id"));
+    }
+
+    @SuppressWarnings("unused")
+    private void validationSample(String id) {
     }
 
 }


### PR DESCRIPTION
## Summary

- **`publish.yml` собирал образ командой `bootJar --no-daemon -x test`.** Workflow висит на том же `push: main`, что и `gradle.yml` с тестами, но независимо от него, поэтому в GHCR под тегом `latest` мог уехать образ с красными тестами. Шаг заменён на `./gradlew build --no-daemon` — тот же jar, но только после тестов.
- **Оба Dockerfile запускали приложение от root.** Сервис ничего не пишет на диск, root ему не нужен. В финальные стадии добавлен системный пользователь `app` (uid 10001), jar копируется с `--chown`, стоит `USER app`.
- **Профили Spring не существовали, хотя выставлялись.** `k8s/deployment.yaml` задаёт `SPRING_PROFILES_ACTIVE=prod`, `docker-compose.yml` — `dev`, а файлов профилей в репозитории не было: обе переменные не значили ничего. При этом в базовом `application.yml` стоял `name.krot.smartlinks: DEBUG` — то есть отладочный уровень действовал и в проде. Базовый уровень стал `INFO`, DEBUG переехал в новый `application-dev.yml` (его и получает compose).
- **`RedirectController.redirect` писал `log.info` на каждый публичный редирект, подставляя в него `HttpServletRequest`.** У реализации Tomcat нет полезного `toString` (`RequestFacade@1f2a3b4`), так что строка была бесполезной, но исправно печаталась на горячем пути. Теперь `log.debug` с id и query string.
- **`GlobalExceptionHandler.handleValidationExceptions` терял часть ошибок валидации:** `errors.put(fieldName, ...)` затирал предыдущее сообщение, а одно поле легко нарушает два правила сразу (`@NotBlank` + `@Pattern`) — клиент видел половину причины. Сообщения объединяются через `merge`.
- **`docker-compose.yml`: том `gradle_cache25` монтировался в рантайм-контейнер.** Сборка идёт внутри образа (томов compose BuildKit не видит), а рантайм-слой — JRE без Gradle вообще: том был мёртвым и только копил мусор. Удалён вместе с объявлением.

## Not changed (needs a decision)

- **Публичный редирект на битом сохранённом правиле отдаёт 400.** `DateRangePredicate` / `PredicateArguments` бросают `IllegalArgumentException`, а `GlobalExceptionHandler` переводит её в `400` с текстом исключения. Тексты — наши собственные («Missing predicate argument 'startWith'»), пользовательский ввод в них не попадает, но статус для GET-редиректа спорный: правило сохранено раньше и клиент тут ни при чём — уместнее 500 или 404. Это изменение контракта API, оставляю на решение.
- **`k8s/deployment.yaml` без `securityContext`.** Теперь, когда образ не root, туда просятся `runAsNonRoot: true` и `allowPrivilegeEscalation: false`, но манифест — вопрос эксплуатации, а не дефект кода.
- **`Dockerfile` (первая стадия) собирает jar тоже с `-x test`.** Для локального `docker compose up` это осознанный компромисс по скорости; публикуемый образ теперь берёт jar из workflow, где тесты идут.

## Test plan

- `./gradlew build --no-daemon` (JDK 25 Temurin, локально) — **BUILD SUCCESSFUL**, тесты и jacoco прошли, включая новый `allValidationMessagesOfOneFieldSurvive`.
- Новый тест воспроизводит потерю: два `FieldError` на поле `id` → в теле ответа обе причины через «; » (до правки оставалась одна).
- `docker compose` и сборка образов локально не проверялись: на ноутбуке нет Docker (CLI — шим на удалённый сервер). Dockerfile-правки узкие: `useradd`, `--chown`, `USER`; jar читается, ничего не пишется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
